### PR TITLE
fix(ci): prevent cargo-dist from creating duplicate GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@
 # * uploads those artifacts to temporary workflow zip
 # * on success, uploads the artifacts to a GitHub Release
 #
-# Note that the GitHub Release will be created with a generated
-# title/body based on your changelogs.
+# Note that a GitHub Release with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 
 name: Release
 permissions:
@@ -269,14 +269,12 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          # If we're editing a release in place, we need to upload things ahead of time
+          gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ targets = [
 ]
 # PR checks run plan-only to catch issues early
 pr-run-mode = "plan"
+# release-please creates the GitHub Release; cargo-dist only uploads artifacts
+create-release = false
 
 # Linux system dependencies for egui/eframe + xcap
 [workspace.metadata.dist.dependencies.apt]


### PR DESCRIPTION
## Summary

- Set `create-release = false` in `[workspace.metadata.dist]` so cargo-dist uploads artifacts to the existing GitHub Release instead of creating a new one
- Regenerated `release.yml` via `dist generate` — the host job now uses `gh release upload` + `gh release edit` instead of `gh release create`

## Problem

The v0.1.3 release had all 5 platform builds passing but the `host` job failed with:
> a release with the same tag name already exists: snap-v0.1.3

This happened because release-please creates the GitHub Release when merging the release PR, then cargo-dist tried to create another release with the same tag.

## Test plan

- [ ] Merge and verify the next release-please cycle completes without conflict
- [ ] Verify cargo-dist uploads binary assets to the release created by release-please