### PR TITLE
docs: add OpenSpec plan for 11 whiteboard features

### DIFF
--- a/openspec/changes/modernise-project/.openspec.yaml
+++ b/openspec/changes/modernise-project/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/modernise-project/design.md
+++ b/openspec/changes/modernise-project/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Snap is a very early-stage native desktop screenshot and whiteboarding app built in Rust with egui. The codebase has 7 source files (~300 lines total), no tests, no CI, and dependencies that are 12 minor versions behind. The project needs a solid foundation before feature work can begin.
+
+Current state:
+- egui 0.21.0 / eframe 0.21.3 (latest is 0.33.3)
+- dark-light 1.0.0 (latest is 2.0.0)
+- No rust-toolchain.toml, no CI, no pre-commit hooks, no .gitignore
+- Dead code (main_using_iced.rs), clippy errors, orphaned serde cfg_attr
+- No crates for core functionality (screenshot capture, hotkeys, image handling, persistence)
+
+The user's other project (streamer, a Tauri app) has a mature CI/CD pipeline that serves as a reference pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All dependencies at latest versions, compiling cleanly with zero warnings
+- New crates added and available for feature development (xcap, global-hotkey, image, serde)
+- CI pipeline running on every PR and push to main (fmt, clippy, check, test)
+- Cross-platform build matrix (Windows, Linux x64/ARM, macOS ARM/Intel) via cargo-dist
+- Automated releases via release-please + cargo-dist
+- Pre-commit hooks enforcing quality locally
+- Clean codebase: no dead code, no clippy errors, no orphaned config
+
+**Non-Goals:**
+- Implementing screenshot capture, hotkey registration, or persistence features (crates are added but not wired up)
+- Writing application tests (no meaningful logic to test yet; CI will run `cargo test` which passes with zero tests)
+- Changing application architecture or UI layout
+- Adding new UI features or modifying existing drawing behaviour
+- Code signing or notarisation for release binaries
+
+## Decisions
+
+### 1. egui migration strategy: direct upgrade to 0.33.3
+**Rationale**: The codebase is small (~300 lines) and the breaking changes are well-documented. An incremental version-by-version upgrade would waste effort on intermediate APIs that are also deprecated. A direct jump is faster and cleaner.
+
+**Key API changes to handle:**
+- `NativeOptions { initial_window_size }` -> `NativeOptions { viewport: ViewportBuilder::default().with_inner_size([w, h]) }`
+- `run_native` closure: `Box::new(|cc| Box::new(...))` -> `Box::new(|cc| Ok(Box::new(...)))`
+- `Frame::canvas(style)` -> verify replacement in 0.33 (likely `Frame::canvas(style)` still exists or replaced by `Frame::new()` pattern)
+- `Sense::drag()` -> verify still available (likely unchanged)
+
+### 2. Pre-commit hooks: shell script in .githooks/
+**Rationale**: Keeps the project pure Rust with no Node dependency. The streamer repo uses husky, but that requires Node/Yarn which is unnecessary for a pure Rust project.
+
+**Implementation**: `.githooks/pre-commit` running `cargo fmt --check && cargo clippy -- -D warnings`. Developers activate with `git config core.hooksPath .githooks`.
+
+**Alternative considered**: cargo-husky crate — rejected because it requires adding a dev-dependency and build script, more complexity than a simple shell script.
+
+### 3. Releases: cargo-dist
+**Rationale**: cargo-dist automates cross-platform binary builds and GitHub Releases with minimal configuration. It generates its own CI workflow, handles platform-specific packaging (.msi, .dmg, .tar.gz), and integrates with release-please.
+
+**Alternative considered**: Manual build matrix (as in streamer's build.yml) — rejected because cargo-dist handles the same thing with less maintenance and better packaging out of the box.
+
+### 4. Serde feature flag: define it properly in Cargo.toml
+**Rationale**: Canvas already has `#[cfg_attr(feature = "serde", ...)]` attributes. Rather than removing them, we should define the feature properly since persistence is a planned capability. Enable it by default.
+
+### 5. Release-please: release-type "rust"
+**Rationale**: Mirrors the streamer repo's pattern but adapted for Rust. release-please has native Rust support that automatically bumps `version` in Cargo.toml.
+
+### 6. New crates added as dependencies but not wired into application logic
+**Rationale**: This change is about modernisation and infrastructure. The crates are declared so they're available and CI validates they compile, but feature implementation is a separate change.
+
+## Risks / Trade-offs
+
+- **[Risk] egui 0.33 API changes break canvas drawing** -> Mitigation: The canvas uses basic `Painter`, `Shape::line`, `Stroke`, `Sense::drag` which are stable across versions. `Frame::canvas` is the main risk; test after migration.
+- **[Risk] cargo-dist generated workflow conflicts with manual workflows** -> Mitigation: cargo-dist manages its own `release.yml`; our manual `checks.yml` and `commit-lint.yml` are separate concerns with no overlap.
+- **[Risk] Pre-commit hooks slow down commits** -> Mitigation: `cargo fmt --check` is near-instant on a small codebase; `cargo clippy` is fast with cached builds. Skip with `--no-verify` in emergencies (but per project conventions, fix the issue instead).
+- **[Risk] dark-light 2.0 API changes** -> Mitigation: dark-light is imported but not yet wired into egui theming. The dependency update is safe; integration is a future task.
+- **[Risk] Unused dependency warnings for newly added crates** -> Mitigation: Add a brief integration point or `use` statement for each crate, or accept the warnings temporarily since the next change will integrate them.

--- a/openspec/changes/modernise-project/proposal.md
+++ b/openspec/changes/modernise-project/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Snap's dependencies are severely outdated (egui/eframe 0.21 vs latest 0.33.3 — 12 minor versions behind) and the project lacks CI/CD, pre-commit hooks, tests, and essential crates for its core screenshot/whiteboard functionality. Modernising now establishes a solid foundation before feature development accelerates.
+
+## What Changes
+
+- **BREAKING**: Upgrade egui 0.21 -> 0.33.3 and eframe 0.21.3 -> 0.33.3 (API changes to `NativeOptions`, `run_native` closure signature, `Frame::canvas` usage)
+- **BREAKING**: Upgrade dark-light 1.0 -> 2.0 (major version bump, API changes)
+- Pin Rust toolchain via `rust-toolchain.toml` (1.93.0)
+- Add new crates: `xcap` (screen capture), `global-hotkey` (system-wide shortcuts), `image` (image encoding/decoding), `serde` + `serde_json` (serialisation/persistence)
+- Delete dead code: `main_using_iced.rs` (abandoned Iced prototype)
+- Fix clippy errors in `footer.rs` (`format!("")` -> `String::new()`, `vec![...]` -> array literal)
+- Fix serde feature flag: either define `serde` feature in Cargo.toml or remove unused `cfg_attr` from canvas.rs
+- Set up `.githooks/pre-commit` shell script running `cargo fmt --check` and `cargo clippy -- -D warnings`
+- Set up GitHub Actions CI: `checks.yml`, `build.yml`, `commit-lint.yml`, `lint-workflows.yml`, `release-please.yml`
+- Set up `cargo-dist` for automated cross-platform release builds (Windows, Linux x64/ARM, macOS ARM/Intel)
+- Add `.gitignore` for Rust target directory and IDE files
+
+## Capabilities
+
+### New Capabilities
+- `ci-pipeline`: GitHub Actions workflows for quality gates (fmt, clippy, check, test), cross-platform builds, commit linting, workflow linting, and release-please automated releases
+- `release-pipeline`: cargo-dist configuration for automated cross-platform binary releases (Windows .msi, Linux .deb, macOS .dmg) triggered by git tags
+- `pre-commit-hooks`: Shell-based git hooks in `.githooks/` mirroring CI checks (fmt + clippy) to shift quality left
+- `dependency-modernisation`: Upgraded egui/eframe to 0.33.3, dark-light to 2.0, and new crates (xcap, global-hotkey, image, serde) integrated and compiling
+
+### Modified Capabilities
+<!-- No existing specs to modify -->
+
+## Impact
+
+- **Cargo.toml**: All dependency versions change, new dependencies added, serde feature flag added
+- **src/main.rs**: `NativeOptions` construction changes (`initial_window_size` -> `viewport`), `run_native` closure now returns `Result`
+- **src/canvas.rs**: `Frame::canvas` usage may need updating, serde cfg_attr either enabled or removed
+- **src/footer.rs**: Clippy fixes (2 lines)
+- **src/main_using_iced.rs**: Deleted entirely
+- **New files**: `rust-toolchain.toml`, `.githooks/pre-commit`, `.github/workflows/` (5 workflow files), `Cargo.toml` cargo-dist config, `.gitignore`
+- **Build system**: cargo-dist adds release profile configuration and CI integration
+- **Developer workflow**: Pre-commit hooks enforce fmt + clippy before every commit

--- a/openspec/changes/modernise-project/specs/ci-pipeline/spec.md
+++ b/openspec/changes/modernise-project/specs/ci-pipeline/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Quality gate checks on every PR and push to main
+The CI system SHALL run `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo check`, and `cargo test` on every pull request and every push to the `main` branch. All checks MUST pass before a PR can be merged.
+
+#### Scenario: PR with formatting violation
+- **WHEN** a pull request contains code that fails `cargo fmt --check`
+- **THEN** the checks workflow SHALL fail and block merging
+
+#### Scenario: PR with clippy warning
+- **WHEN** a pull request contains code that triggers a clippy warning
+- **THEN** the checks workflow SHALL fail (clippy runs with `-D warnings`)
+
+#### Scenario: All checks pass
+- **WHEN** a pull request passes fmt, clippy, check, and test
+- **THEN** the checks workflow SHALL succeed and allow merging
+
+### Requirement: Cross-platform build verification on every PR
+The CI system SHALL build the project on all target platforms (Windows, Ubuntu x64, Ubuntu ARM, macOS ARM, macOS Intel) for every pull request to verify cross-platform compilation.
+
+#### Scenario: PR build matrix
+- **WHEN** a pull request is opened or updated
+- **THEN** the build workflow SHALL compile the project on all 5 platform targets with `fail-fast: false`
+
+#### Scenario: Platform-specific build failure
+- **WHEN** the build fails on one platform but succeeds on others
+- **THEN** all platform builds SHALL still run to completion (fail-fast disabled) and the failing platform SHALL be reported
+
+### Requirement: Conventional commit enforcement on PRs
+The CI system SHALL enforce conventional commit format on pull request titles using `amannn/action-semantic-pull-request`. Accepted types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
+
+#### Scenario: Non-conventional PR title
+- **WHEN** a pull request has a title like "updated stuff"
+- **THEN** the commit-lint workflow SHALL fail
+
+#### Scenario: Conventional PR title
+- **WHEN** a pull request has a title like "feat: add screenshot capture"
+- **THEN** the commit-lint workflow SHALL pass
+
+### Requirement: Workflow file linting
+The CI system SHALL lint GitHub Actions workflow files using `reviewdog/action-actionlint` whenever workflow files are modified in a PR.
+
+#### Scenario: Invalid workflow syntax
+- **WHEN** a PR modifies a file in `.github/workflows/` with invalid YAML or action syntax
+- **THEN** the lint-workflows job SHALL fail and report the issue
+
+#### Scenario: No workflow changes
+- **WHEN** a PR does not modify any files in `.github/workflows/`
+- **THEN** the lint-workflows job SHALL not run (path filter)
+
+### Requirement: Rust build caching
+The CI system SHALL use `swatinem/rust-cache@v2` to cache Rust build artefacts across CI runs to reduce build times.
+
+#### Scenario: Cached build
+- **WHEN** a CI run starts with a warm cache from a previous run
+- **THEN** the build SHALL reuse cached compilation artefacts and complete faster than a cold build
+
+### Requirement: Rust toolchain setup
+The CI system SHALL use `dtolnay/rust-toolchain@stable` with `clippy` and `rustfmt` components to ensure consistent toolchain across all CI runs.
+
+#### Scenario: Toolchain installation
+- **WHEN** a CI workflow starts
+- **THEN** the stable Rust toolchain SHALL be installed with clippy and rustfmt components available

--- a/openspec/changes/modernise-project/specs/dependency-modernisation/spec.md
+++ b/openspec/changes/modernise-project/specs/dependency-modernisation/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Rust toolchain pinned via rust-toolchain.toml
+The project SHALL include a `rust-toolchain.toml` file pinning the Rust toolchain to stable channel version 1.93.0 with clippy and rustfmt components.
+
+#### Scenario: Developer with different default toolchain
+- **WHEN** a developer with a different default Rust version enters the project directory
+- **THEN** rustup SHALL automatically use the pinned toolchain version
+
+### Requirement: egui and eframe upgraded to 0.33.3
+The project SHALL use egui 0.33.3 and eframe 0.33.3. All API changes MUST be migrated:
+- `NativeOptions::initial_window_size` replaced with `viewport: egui::ViewportBuilder::default().with_inner_size([1680.0, 1050.0])`
+- `run_native` closure returns `Result`: `Box::new(|cc| Ok(Box::new(...)))`
+- Any deprecated APIs (e.g. `Frame::canvas`) replaced with current equivalents
+
+#### Scenario: Application starts successfully
+- **WHEN** the application is launched with `cargo run`
+- **THEN** the window SHALL open at 1680x1050 with the same layout as before (header, footer, side panel, canvas)
+
+#### Scenario: Drawing still works
+- **WHEN** a user draws on the canvas after the upgrade
+- **THEN** freehand lines SHALL render correctly using the same normalised coordinate system
+
+### Requirement: dark-light upgraded to 2.0
+The project SHALL use dark-light 2.0. The crate is imported but not yet wired into the UI; the upgrade MUST NOT break compilation.
+
+#### Scenario: Compilation succeeds
+- **WHEN** the project is compiled with dark-light 2.0
+- **THEN** `cargo check` SHALL pass without errors
+
+### Requirement: New crates added to Cargo.toml
+The project SHALL add the following dependencies: `xcap` (latest), `global-hotkey` (latest), `image` (latest), `serde` with `derive` feature, and `serde_json` (latest). These crates MUST compile but are not required to be integrated into application logic.
+
+#### Scenario: All new crates compile
+- **WHEN** the project is compiled with all new dependencies
+- **THEN** `cargo check` SHALL pass without errors
+
+### Requirement: Serde feature flag properly defined
+The `serde` feature SHALL be defined in `Cargo.toml` under `[features]` and SHALL enable `serde` as an optional dependency. The `cfg_attr` attributes on the `Canvas` struct SHALL work correctly when the feature is enabled.
+
+#### Scenario: Serde feature enabled
+- **WHEN** the project is compiled with `cargo check --features serde`
+- **THEN** the `Canvas` struct SHALL derive `serde::Serialize` and `serde::Deserialize`
+
+#### Scenario: Default compilation without serde feature
+- **WHEN** the project is compiled with `cargo check` (no features)
+- **THEN** no serde-related warnings SHALL appear
+
+### Requirement: Dead code removed
+The file `src/main_using_iced.rs` SHALL be deleted. It is an abandoned Iced prototype that is not compiled or referenced.
+
+#### Scenario: File deleted
+- **WHEN** the source tree is inspected after this change
+- **THEN** `src/main_using_iced.rs` SHALL not exist
+
+### Requirement: Clippy errors in footer.rs fixed
+The two clippy errors in `footer.rs` SHALL be fixed:
+- `format!("")` on line 39 replaced with `String::new()`
+- `vec!["...", "...", "..."]` on line 30 replaced with an array literal `["...", "...", "..."]`
+
+#### Scenario: Clippy passes
+- **WHEN** `cargo clippy -- -D warnings` is run
+- **THEN** zero errors and zero warnings SHALL be reported
+
+### Requirement: .gitignore file added
+The project SHALL include a `.gitignore` file ignoring at minimum: `target/`, IDE files (`.idea/`, `.vscode/`, `*.swp`, `*.swo`), and OS files (`.DS_Store`, `Thumbs.db`).
+
+#### Scenario: Build artefacts not tracked
+- **WHEN** `cargo build` creates the `target/` directory
+- **THEN** git SHALL not show `target/` files as untracked
+
+### Requirement: All quality checks pass
+After all changes, `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo check`, and `cargo test` SHALL all pass with zero errors and zero warnings.
+
+#### Scenario: Full quality check suite
+- **WHEN** all modernisation changes are applied
+- **THEN** running `cargo fmt --check && cargo clippy -- -D warnings && cargo check && cargo test` SHALL exit with code 0

--- a/openspec/changes/modernise-project/specs/pre-commit-hooks/spec.md
+++ b/openspec/changes/modernise-project/specs/pre-commit-hooks/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Pre-commit hook runs format and lint checks
+A git pre-commit hook at `.githooks/pre-commit` SHALL run `cargo fmt --check` and `cargo clippy -- -D warnings` before every commit. The hook MUST mirror the CI quality checks.
+
+#### Scenario: Code with formatting issues
+- **WHEN** a developer attempts to commit code that fails `cargo fmt --check`
+- **THEN** the pre-commit hook SHALL reject the commit with an error message
+
+#### Scenario: Code with clippy warnings
+- **WHEN** a developer attempts to commit code that triggers clippy warnings
+- **THEN** the pre-commit hook SHALL reject the commit with an error message
+
+#### Scenario: Clean code
+- **WHEN** a developer attempts to commit code that passes both fmt and clippy
+- **THEN** the pre-commit hook SHALL allow the commit to proceed
+
+### Requirement: Hook activation via git config
+The project SHALL document and support activating pre-commit hooks via `git config core.hooksPath .githooks`. This MUST NOT require Node.js, Python, or any non-Rust tooling.
+
+#### Scenario: Developer activates hooks
+- **WHEN** a developer runs `git config core.hooksPath .githooks` in the repository
+- **THEN** all subsequent commits SHALL trigger the pre-commit hook
+
+#### Scenario: No automatic activation
+- **WHEN** a developer clones the repository without running the git config command
+- **THEN** no pre-commit hooks SHALL run (opt-in, not mandatory)

--- a/openspec/changes/modernise-project/specs/release-pipeline/spec.md
+++ b/openspec/changes/modernise-project/specs/release-pipeline/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Automated release PR creation via release-please
+The release system SHALL use `googleapis/release-please-action@v4` with `release-type: "rust"` to automatically create release PRs from conventional commits pushed to `main`. The release PR SHALL update the version in `Cargo.toml` and maintain a `CHANGELOG.md`.
+
+#### Scenario: Feature commit pushed to main
+- **WHEN** a commit with prefix `feat:` is pushed to the `main` branch
+- **THEN** release-please SHALL create or update a release PR with a minor version bump and updated CHANGELOG
+
+#### Scenario: Fix commit pushed to main
+- **WHEN** a commit with prefix `fix:` is pushed to the `main` branch
+- **THEN** release-please SHALL create or update a release PR with a patch version bump and updated CHANGELOG
+
+#### Scenario: Release PR merged
+- **WHEN** a release-please PR is merged
+- **THEN** release-please SHALL create a git tag `v<version>` which triggers the release build
+
+### Requirement: Cross-platform binary releases via cargo-dist
+The release system SHALL use cargo-dist to build and publish release binaries for Windows (x86_64), Linux (x86_64, aarch64), and macOS (aarch64, x86_64) when a version tag is pushed.
+
+#### Scenario: Version tag pushed
+- **WHEN** a git tag matching `v*` is pushed
+- **THEN** cargo-dist SHALL build release binaries for all 5 platform targets and create a GitHub Release with downloadable assets
+
+#### Scenario: Release assets
+- **WHEN** a GitHub Release is created by cargo-dist
+- **THEN** the release SHALL contain platform-appropriate installers/archives (e.g. .msi for Windows, .tar.gz for Linux, .dmg for macOS)
+
+### Requirement: Release token for tag-triggered builds
+The release system SHALL use a custom `RELEASE_TOKEN` secret (not the default `GITHUB_TOKEN`) for release-please so that the tag push triggers downstream build workflows.
+
+#### Scenario: Tag triggers build
+- **WHEN** release-please creates a tag using `RELEASE_TOKEN`
+- **THEN** the cargo-dist release workflow SHALL be triggered by the tag event

--- a/openspec/changes/modernise-project/tasks.md
+++ b/openspec/changes/modernise-project/tasks.md
@@ -1,0 +1,63 @@
+## 1. Project housekeeping
+
+- [ ] 1.1 Delete `src/main_using_iced.rs` (dead code)
+- [ ] 1.2 Add `.gitignore` (target/, .idea/, .vscode/, *.swp, *.swo, .DS_Store, Thumbs.db, .openspec/)
+- [ ] 1.3 Add `rust-toolchain.toml` pinning stable 1.93.0 with clippy and rustfmt components
+
+## 2. Fix existing code issues
+
+- [ ] 2.1 Fix clippy error in `footer.rs:39`: replace `format!("")` with `String::new()`
+- [ ] 2.2 Fix clippy error in `footer.rs:30`: replace `vec![...]` with array literal `[...]`
+
+## 3. Upgrade dependencies
+
+- [ ] 3.1 Upgrade `egui` from 0.21.0 to 0.33.3 and `eframe` from 0.21.3 to 0.33.3 in Cargo.toml
+- [ ] 3.2 Migrate `main.rs`: replace `NativeOptions { initial_window_size }` with `viewport: egui::ViewportBuilder::default().with_inner_size([1680.0, 1050.0])`
+- [ ] 3.3 Migrate `main.rs`: update `run_native` closure to return `Result` — `Box::new(|cc| Ok(Box::new(...)))`
+- [ ] 3.4 Migrate `canvas.rs`: verify and fix `Frame::canvas(ui.style())` usage for egui 0.33 API
+- [ ] 3.5 Migrate any other breaking API changes found during compilation (e.g. `Sense`, `stroke_ui`, etc.)
+- [ ] 3.6 Upgrade `dark-light` from 1.0.0 to 2.0.0 in Cargo.toml (verify compilation, no integration changes needed)
+
+## 4. Add new dependencies
+
+- [ ] 4.1 Add `xcap` (latest) to Cargo.toml
+- [ ] 4.2 Add `global-hotkey` (latest) to Cargo.toml
+- [ ] 4.3 Add `image` (latest) to Cargo.toml
+- [ ] 4.4 Add `serde` with `derive` feature and `serde_json` to Cargo.toml
+- [ ] 4.5 Define `serde` feature flag in `[features]` section; make serde an optional dependency; fix `cfg_attr` in `canvas.rs` to compile cleanly with and without the feature
+
+## 5. Verify everything compiles and passes
+
+- [ ] 5.1 Run `cargo fmt --check` — must pass
+- [ ] 5.2 Run `cargo clippy -- -D warnings` — must pass with zero warnings
+- [ ] 5.3 Run `cargo check` — must pass
+- [ ] 5.4 Run `cargo test` — must pass
+- [ ] 5.5 Run `cargo run` — verify app launches, window renders, drawing works
+
+## 6. Pre-commit hooks
+
+- [ ] 6.1 Create `.githooks/pre-commit` shell script: `cargo fmt --check && cargo clippy -- -D warnings`
+- [ ] 6.2 Make `.githooks/pre-commit` executable (`chmod +x`)
+- [ ] 6.3 Document hook activation in CLAUDE.md or README: `git config core.hooksPath .githooks`
+
+## 7. GitHub Actions CI
+
+- [ ] 7.1 Create `.github/workflows/checks.yml`: fmt, clippy, check, test on PR + push to main (using dtolnay/rust-toolchain@stable, swatinem/rust-cache@v2)
+- [ ] 7.2 Create `.github/workflows/build.yml`: cross-platform build matrix (Windows, Ubuntu x64, Ubuntu ARM, macOS ARM, macOS Intel) on PR + tags
+- [ ] 7.3 Create `.github/workflows/commit-lint.yml`: enforce conventional commits on PR titles (amannn/action-semantic-pull-request@v5)
+- [ ] 7.4 Create `.github/workflows/lint-workflows.yml`: actionlint on workflow file changes (reviewdog/action-actionlint@v1)
+- [ ] 7.5 Create `.github/workflows/release-please.yml`: automated release PRs (googleapis/release-please-action@v4 with release-type: rust)
+- [ ] 7.6 Create `release-please-config.json` and `.release-please-manifest.json`
+
+## 8. cargo-dist release pipeline
+
+- [ ] 8.1 Install cargo-dist locally and run `cargo dist init` to generate initial config
+- [ ] 8.2 Configure cargo-dist for 5 target platforms (Windows x64, Linux x64, Linux ARM, macOS ARM, macOS Intel)
+- [ ] 8.3 Verify cargo-dist generated workflow integrates with release-please tag flow
+- [ ] 8.4 Test `cargo dist build` locally to verify it produces artefacts
+
+## 9. Final verification
+
+- [ ] 9.1 Run full quality check suite: `cargo fmt --check && cargo clippy -- -D warnings && cargo check && cargo test`
+- [ ] 9.2 Verify pre-commit hook works: activate hooks, make a commit with intentional fmt issue, confirm rejection
+- [ ] 9.3 Review all new/modified files for completeness

--- a/openspec/changes/whiteboard-features/.openspec.yaml
+++ b/openspec/changes/whiteboard-features/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/whiteboard-features/design.md
+++ b/openspec/changes/whiteboard-features/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Snap is a ~300-line Rust/egui desktop app with a basic freehand drawing canvas. The canvas stores lines as `Vec<Vec<Pos2>>` with a single shared `Stroke`. The footer has palette buttons and an eraser button that only `println!` — no state flows between components. There is no shared app state; each component owns its own data. egui is immediate-mode (full redraw every frame), so state must live outside the UI code and be passed in.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce a shared `AppState` that all components read/write, enabling tool selection, colour, and thickness to flow from footer to canvas
+- Store per-stroke metadata (colour, width, tool type) so strokes render independently
+- Introduce a `DrawObject` enum (freehand, rect, ellipse, line, arrow, text, image) as the unified canvas element
+- Add an undo/redo command stack operating on `DrawObject` additions/removals/mutations
+- Add shape selection with hit-testing, bounding box handles, and keyboard delete
+- Integrate xcap for screen capture, image crate for PNG export, and system clipboard via arboard
+- Wire dark-light crate to set egui `Visuals` on startup and optionally toggle at runtime
+
+**Non-Goals:**
+- Layers or grouping — single flat list of draw objects for now
+- Vector export (SVG) — only raster PNG export
+- Multi-page or infinite canvas — single viewport with no zoom/pan
+- Collaborative/multi-user features
+- Plugin or extension system
+- Touch gesture handling beyond basic pointer events
+
+## Decisions
+
+### 1. Shared AppState struct
+**Decision:** Introduce `AppState` in `state.rs` holding active tool, active colour, stroke width, theme, and a `Vec<DrawObject>` for canvas contents. Pass `&mut AppState` to all component `render()` calls.
+**Rationale:** egui is immediate-mode — there's no reactive binding. A single mutable state struct is the idiomatic pattern. Alternatives (message passing, channels) add complexity without benefit for a single-threaded GUI.
+
+### 2. DrawObject enum as unified canvas element
+**Decision:** Replace `Vec<Vec<Pos2>>` with `Vec<DrawObject>` where `DrawObject` is an enum: `Freehand { points, colour, width }`, `Rectangle { rect, colour, width, filled }`, `Ellipse { ... }`, `Line { start, end, colour, width }`, `Arrow { ... }`, `Text { pos, content, font_size, colour }`, `Image { pos, texture_handle, size }`.
+**Rationale:** A unified enum lets selection, undo/redo, serialisation, and rendering operate generically over all shape types. Using trait objects would complicate serialisation and cloning.
+
+### 3. Command-based undo/redo
+**Decision:** Use a `Vec<Command>` history stack with a cursor index. Commands: `Add(DrawObject)`, `Remove(index)`, `Modify(index, old, new)`. Undo replays in reverse; redo replays forward.
+**Rationale:** Command pattern is standard for undo/redo. Storing full snapshots would waste memory for large drawings. The command list also enables future "replay" features.
+
+### 4. Hit-testing for selection
+**Decision:** Implement per-DrawObject `contains(pos) -> bool` and `bounding_rect() -> Rect`. For freehand strokes, use distance-to-polyline with a tolerance threshold. For shapes, use geometric containment. Selected objects get a dashed bounding box overlay with drag handles.
+**Rationale:** Per-object hit-testing is simple and fast for the expected object counts (<1000). Spatial indexing (R-tree) would be premature.
+
+### 5. Eraser via stroke removal
+**Decision:** Eraser tool checks pointer position against all objects using hit-testing. Objects the pointer passes over are removed (added to undo stack as `Remove` commands). This is whole-object erasure, not pixel-level.
+**Rationale:** Whole-object erasure is simpler and matches the vector-based data model. Pixel-level erasure would require rasterisation.
+
+### 6. Screenshot capture flow
+**Decision:** Minimise Snap window → capture with xcap → restore window → load captured image as `DrawObject::Image` on canvas. Use `xcap::Monitor::all()` for multi-monitor support and `Monitor::capture_image()` for the actual grab.
+**Rationale:** xcap is already a dependency. The minimise/capture/restore flow is standard for screenshot tools. Region selection will overlay a translucent selection rect on the captured image.
+
+### 7. Theme detection and switching
+**Decision:** Call `dark_light::detect()` at startup to set initial `egui::Visuals`. Add a toggle button in the header. Store theme preference in AppState.
+**Rationale:** dark-light is already imported. egui has built-in `Visuals::dark()` and `Visuals::light()`.
+
+### 8. Clipboard via arboard crate
+**Decision:** Add `arboard` dependency for cross-platform clipboard. Copy renders the selection (or full canvas) to an image buffer and copies to clipboard. Paste reads clipboard image and creates `DrawObject::Image`.
+**Rationale:** egui's built-in clipboard is text-only. `arboard` handles image clipboard on Windows, macOS, and Linux (X11/Wayland).
+
+### 9. PNG export via image crate
+**Decision:** Render all DrawObjects to an off-screen buffer using egui's `ColorImage`, then save via `image::save_buffer()`. Use `rfd` (or native file dialog via egui) for save path selection.
+**Rationale:** The `image` crate is already a dependency. Off-screen rendering avoids depending on the current viewport state.
+
+### 10. Module structure
+**Decision:** New modules: `state.rs` (AppState + DrawObject + Tool enum), `history.rs` (undo/redo stack), `tools/` directory with `mod.rs`, `freehand.rs`, `shapes.rs`, `text.rs`, `eraser.rs`, `selection.rs`. Keep `screenshot.rs`, `export.rs`, `clipboard.rs` as separate modules.
+**Rationale:** Domain-driven structure per AGENTS.md. Each tool encapsulates its own input handling and rendering logic.
+
+## Risks / Trade-offs
+
+- **Off-screen rendering for export** — egui doesn't natively support off-screen rendering. May need to render to a texture and read back pixels, which is GPU-dependent. → Mitigation: For MVP, screenshot the canvas panel area; full off-screen rendering can be a follow-up.
+- **Clipboard image format** — arboard's image support varies by platform. → Mitigation: Test on Windows first (primary target), degrade gracefully on other platforms.
+- **Screenshot on Wayland** — xcap may have limited Wayland support. → Mitigation: Primary target is Windows; Linux support via X11 initially.
+- **Performance with many objects** — Rendering hundreds of shapes every frame in immediate-mode. → Mitigation: egui handles this well for <1000 shapes. Optimise later if needed.
+- **Breaking change to canvas data model** — Replacing `Vec<Vec<Pos2>>` with `Vec<DrawObject>` is a complete rewrite of canvas.rs. → Mitigation: All features depend on this change; it's the necessary foundation.

--- a/openspec/changes/whiteboard-features/proposal.md
+++ b/openspec/changes/whiteboard-features/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Snap currently has a canvas that draws freehand lines with a single hardcoded colour and stroke width. The palette buttons and eraser print to console but don't affect the canvas. None of the whiteboard or screenshot features work yet. To become a usable replacement for Snipping Tool and Microsoft Whiteboard, Snap needs functional drawing tools, editing capabilities, and screenshot/export workflows.
+
+## What Changes
+
+- Wire palette colour buttons to actually change the canvas stroke colour
+- Add a working eraser that removes strokes
+- Add adjustable line thickness (stroke width control)
+- Add shape selection — click to select, move, and delete drawn shapes
+- Add undo/redo with Ctrl+Z / Ctrl+Y history stack
+- Add shape drawing tools: rectangle, ellipse, straight line, arrow
+- Add screenshot capture using the xcap crate to capture screen regions
+- Wire up dark-light crate to detect and apply OS theme (dark/light mode)
+- Add export to PNG — save the canvas as an image file
+- Add text annotations — place and edit text on the canvas
+- Add clipboard copy/paste — copy canvas content to clipboard, paste images onto canvas
+
+## Capabilities
+
+### New Capabilities
+
+- `drawing-colours`: Palette buttons change the active stroke colour; each stroke stores its own colour
+- `eraser`: Eraser tool that removes strokes the pointer passes over
+- `line-thickness`: UI control for stroke width; each stroke stores its own thickness
+- `shape-selection`: Select, move, and delete drawn shapes on the canvas
+- `undo-redo`: Ctrl+Z / Ctrl+Y history stack for all canvas operations
+- `shape-tools`: Rectangle, ellipse, straight line, and arrow drawing tools
+- `screenshot-capture`: Capture screen regions using xcap and load them onto the canvas
+- `theme-switching`: Detect OS theme via dark-light crate and apply matching egui visuals
+- `export-png`: Save the current canvas content as a PNG image file
+- `text-annotations`: Place, edit, and style text labels on the canvas
+- `clipboard`: Copy canvas/selection to system clipboard; paste images onto canvas
+
+### Modified Capabilities
+
+_(none — no existing specs)_
+
+## Impact
+
+- **canvas.rs**: Major refactor — strokes need per-stroke colour, width, and type; new data model for shapes, text, and images; selection and hit-testing logic; undo/redo command stack
+- **footer.rs**: Wire colour buttons and eraser to shared app state; add thickness slider; add shape tool buttons
+- **header.rs**: Add undo/redo buttons, export/screenshot actions, theme toggle
+- **main.rs**: Introduce shared `AppState` struct passed to all components; keyboard shortcut handling
+- **palette.rs**: Minor — already functional, just needs to communicate selected colour to canvas
+- **New modules**: `tools.rs` (tool enum + behaviour), `history.rs` (undo/redo), `screenshot.rs` (xcap integration), `export.rs` (PNG save), `clipboard.rs` (system clipboard)
+- **Dependencies**: All needed crates already in Cargo.toml (xcap, global-hotkey, image, dark-light). May need `arboard` crate for clipboard access.

--- a/openspec/changes/whiteboard-features/specs/clipboard/spec.md
+++ b/openspec/changes/whiteboard-features/specs/clipboard/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Copy selection to clipboard
+The system SHALL copy the selected object(s) or full canvas as an image to the system clipboard when Ctrl+C is pressed.
+
+#### Scenario: Copying a selected object
+- **WHEN** an object is selected and user presses Ctrl+C
+- **THEN** the selected object is rendered as an image and placed on the system clipboard
+
+#### Scenario: Copying with no selection
+- **WHEN** no object is selected and user presses Ctrl+C
+- **THEN** the entire canvas is rendered as an image and placed on the system clipboard
+
+### Requirement: Paste image from clipboard
+The system SHALL paste clipboard image content onto the canvas as a DrawObject::Image when Ctrl+V is pressed.
+
+#### Scenario: Pasting an image
+- **WHEN** the system clipboard contains an image and user presses Ctrl+V
+- **THEN** the image appears on the canvas as a new DrawObject::Image at the centre of the viewport
+
+#### Scenario: Pasting with no image in clipboard
+- **WHEN** the clipboard does not contain an image and user presses Ctrl+V
+- **THEN** nothing happens (no crash, no visual change)
+
+### Requirement: Clipboard uses arboard crate
+The system SHALL use the `arboard` crate for cross-platform clipboard image support.
+
+#### Scenario: Clipboard on Windows
+- **WHEN** user copies or pastes on Windows
+- **THEN** the system clipboard is accessed via arboard with image support

--- a/openspec/changes/whiteboard-features/specs/drawing-colours/spec.md
+++ b/openspec/changes/whiteboard-features/specs/drawing-colours/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Palette buttons set active stroke colour
+The system SHALL update the active stroke colour in AppState when a palette button is clicked. The footer palette buttons SHALL provide visual feedback showing which colour is currently selected.
+
+#### Scenario: User clicks a palette colour
+- **WHEN** user clicks a palette colour button in the footer
+- **THEN** the active stroke colour in AppState updates to that colour and the button displays a selected indicator (e.g., border highlight)
+
+### Requirement: Each stroke stores its own colour
+The system SHALL store the colour with each DrawObject at creation time. Previously drawn objects SHALL retain their original colour when the active colour changes.
+
+#### Scenario: Drawing with different colours
+- **WHEN** user draws a stroke with red, changes to blue, then draws another stroke
+- **THEN** the first stroke remains red and the second stroke is blue
+
+### Requirement: Default colour on startup
+The system SHALL start with black (palette index 0) as the default active colour.
+
+#### Scenario: Application launch
+- **WHEN** the application starts
+- **THEN** the first palette colour (black) is selected and new strokes draw in black

--- a/openspec/changes/whiteboard-features/specs/eraser/spec.md
+++ b/openspec/changes/whiteboard-features/specs/eraser/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Eraser tool removes whole objects
+The system SHALL provide an eraser tool that removes entire DrawObjects when the pointer passes over them. The eraser SHALL use hit-testing with a configurable tolerance radius.
+
+#### Scenario: Erasing a freehand stroke
+- **WHEN** the eraser tool is active and the user drags the pointer over a freehand stroke
+- **THEN** the stroke is removed from the canvas and a Remove command is pushed to the undo stack
+
+#### Scenario: Erasing a shape
+- **WHEN** the eraser tool is active and the user clicks on a rectangle or ellipse
+- **THEN** the shape is removed from the canvas
+
+### Requirement: Eraser button in footer activates eraser tool
+The system SHALL include an eraser button in the footer toolbar. Clicking it SHALL set the active tool to Eraser.
+
+#### Scenario: Switching to eraser
+- **WHEN** user clicks the eraser button (E) in the footer
+- **THEN** the active tool changes to Eraser and the eraser button shows a selected indicator
+
+### Requirement: Eraser cursor visual feedback
+The system SHALL display a circle cursor indicating the eraser radius when the eraser tool is active.
+
+#### Scenario: Eraser active on canvas
+- **WHEN** the eraser tool is active and the pointer is over the canvas
+- **THEN** a circle is drawn at the pointer position showing the erase radius

--- a/openspec/changes/whiteboard-features/specs/export-png/spec.md
+++ b/openspec/changes/whiteboard-features/specs/export-png/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Export canvas as PNG
+The system SHALL export the current canvas content as a PNG image file. A file save dialog SHALL let the user choose the destination path.
+
+#### Scenario: Exporting to PNG
+- **WHEN** user triggers export and selects a save path
+- **THEN** the canvas contents are rendered to a PNG file at the chosen path
+
+### Requirement: Export action in header
+The system SHALL provide an export/save button in the header toolbar.
+
+#### Scenario: Clicking export button
+- **WHEN** user clicks the export button in the header
+- **THEN** a file save dialog opens with PNG as the default format
+
+### Requirement: Export includes all visible objects
+The system SHALL include all DrawObjects currently on the canvas in the exported image, rendered at their current positions and styles.
+
+#### Scenario: Exporting with multiple shapes
+- **WHEN** canvas has freehand strokes, rectangles, and text, and user exports
+- **THEN** the PNG file contains all objects rendered correctly
+
+### Requirement: Export respects canvas background
+The system SHALL use the current canvas background colour (matching the active theme) as the PNG background.
+
+#### Scenario: Export in dark mode
+- **WHEN** user exports while in dark mode
+- **THEN** the PNG has a dark background matching the canvas

--- a/openspec/changes/whiteboard-features/specs/line-thickness/spec.md
+++ b/openspec/changes/whiteboard-features/specs/line-thickness/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Stroke width control in footer
+The system SHALL display a thickness slider or preset buttons in the footer toolbar. The control SHALL update the active stroke width in AppState.
+
+#### Scenario: Adjusting line thickness
+- **WHEN** user changes the thickness control to 4px
+- **THEN** the active stroke width updates to 4.0 and new strokes draw at that width
+
+### Requirement: Each stroke stores its own width
+The system SHALL store the stroke width with each DrawObject at creation time. Changing thickness SHALL NOT affect previously drawn objects.
+
+#### Scenario: Drawing with different thicknesses
+- **WHEN** user draws a stroke at 2px, changes to 6px, then draws another
+- **THEN** the first stroke remains 2px and the second is 6px
+
+### Requirement: Default stroke width
+The system SHALL start with a default stroke width of 2px.
+
+#### Scenario: Application launch
+- **WHEN** the application starts
+- **THEN** the stroke width is set to 2.0px
+
+### Requirement: Thickness presets
+The system SHALL offer at least 4 thickness presets: thin (1px), medium (2px), thick (4px), extra-thick (8px).
+
+#### Scenario: Selecting a thickness preset
+- **WHEN** user clicks the "thick" preset button
+- **THEN** the active stroke width changes to 4.0px

--- a/openspec/changes/whiteboard-features/specs/screenshot-capture/spec.md
+++ b/openspec/changes/whiteboard-features/specs/screenshot-capture/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Capture full screen
+The system SHALL capture the full screen when the screenshot action is triggered. The captured image SHALL be loaded onto the canvas as a DrawObject::Image.
+
+#### Scenario: Full screen capture
+- **WHEN** user triggers screenshot capture
+- **THEN** the Snap window minimises, the screen is captured, the window restores, and the image appears on the canvas
+
+### Requirement: Screenshot action in header
+The system SHALL provide a screenshot button in the header toolbar to trigger capture.
+
+#### Scenario: Clicking screenshot button
+- **WHEN** user clicks the screenshot button in the header
+- **THEN** the screenshot capture flow begins (minimise → capture → restore → load)
+
+### Requirement: Multi-monitor support
+The system SHALL capture from the primary monitor by default. If multiple monitors are detected, the system SHALL capture from the monitor where the Snap window is displayed.
+
+#### Scenario: Multi-monitor capture
+- **WHEN** user triggers screenshot on a multi-monitor setup
+- **THEN** the primary monitor's screen is captured
+
+### Requirement: Region selection after capture
+The system SHALL allow the user to select a rectangular region of the captured image to crop. The cropped region becomes the canvas content.
+
+#### Scenario: Selecting a region
+- **WHEN** a full screen capture is taken and the selection overlay appears
+- **THEN** user can drag to select a rectangle, and only that region is kept on the canvas

--- a/openspec/changes/whiteboard-features/specs/shape-selection/spec.md
+++ b/openspec/changes/whiteboard-features/specs/shape-selection/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Selection tool selects objects on click
+The system SHALL provide a selection tool. When active, clicking on a DrawObject SHALL select it, displaying a bounding box with handles.
+
+#### Scenario: Clicking on a shape
+- **WHEN** selection tool is active and user clicks on a drawn rectangle
+- **THEN** the rectangle is selected with a visible bounding box around it
+
+#### Scenario: Clicking on empty canvas
+- **WHEN** selection tool is active and user clicks on an empty area
+- **THEN** any current selection is cleared
+
+### Requirement: Move selected objects
+The system SHALL allow dragging a selected object to move it to a new position. The move SHALL be recorded as a Modify command in the undo stack.
+
+#### Scenario: Dragging a selected shape
+- **WHEN** user drags a selected object
+- **THEN** the object moves with the pointer and its position updates in AppState
+
+### Requirement: Delete selected objects
+The system SHALL delete selected objects when the Delete or Backspace key is pressed.
+
+#### Scenario: Deleting a selection
+- **WHEN** an object is selected and the user presses Delete
+- **THEN** the object is removed from the canvas and a Remove command is pushed to the undo stack
+
+### Requirement: Selection visual feedback
+The system SHALL render a dashed bounding rectangle around selected objects with distinct styling (e.g., blue dashed border).
+
+#### Scenario: Object selected
+- **WHEN** an object is selected
+- **THEN** a dashed blue rectangle is drawn around the object's bounding box

--- a/openspec/changes/whiteboard-features/specs/shape-tools/spec.md
+++ b/openspec/changes/whiteboard-features/specs/shape-tools/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Rectangle drawing tool
+The system SHALL provide a rectangle tool. When active, click-and-drag SHALL create a rectangle from the start point to the release point, using the active colour and stroke width.
+
+#### Scenario: Drawing a rectangle
+- **WHEN** rectangle tool is active and user click-drags from point A to point B
+- **THEN** a rectangle is drawn with corners at A and B, using the active colour and width
+
+#### Scenario: Rectangle preview while dragging
+- **WHEN** user is mid-drag with the rectangle tool
+- **THEN** a preview rectangle is shown following the pointer
+
+### Requirement: Ellipse drawing tool
+The system SHALL provide an ellipse tool. Click-and-drag SHALL create an ellipse inscribed in the rectangle from start to release point.
+
+#### Scenario: Drawing an ellipse
+- **WHEN** ellipse tool is active and user click-drags from point A to point B
+- **THEN** an ellipse inscribed in the bounding rect A→B is drawn with active colour and width
+
+### Requirement: Straight line tool
+The system SHALL provide a line tool. Click-and-drag SHALL draw a straight line from start to release point.
+
+#### Scenario: Drawing a straight line
+- **WHEN** line tool is active and user click-drags from point A to point B
+- **THEN** a straight line from A to B is drawn with active colour and width
+
+### Requirement: Arrow tool
+The system SHALL provide an arrow tool. Click-and-drag SHALL draw a line with an arrowhead at the end point.
+
+#### Scenario: Drawing an arrow
+- **WHEN** arrow tool is active and user click-drags from point A to point B
+- **THEN** a line with an arrowhead pointing at B is drawn with active colour and width
+
+### Requirement: Shape tool buttons in footer
+The system SHALL display tool buttons for rectangle, ellipse, line, and arrow in the footer toolbar alongside the existing freehand tools.
+
+#### Scenario: Switching to rectangle tool
+- **WHEN** user clicks the rectangle tool button
+- **THEN** the active tool changes to Rectangle and the button shows a selected indicator

--- a/openspec/changes/whiteboard-features/specs/text-annotations/spec.md
+++ b/openspec/changes/whiteboard-features/specs/text-annotations/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Text tool places editable text on canvas
+The system SHALL provide a text tool. When active, clicking on the canvas SHALL create an inline text editing area at that position. The user types text and it becomes a DrawObject::Text on the canvas.
+
+#### Scenario: Adding text
+- **WHEN** text tool is active and user clicks on the canvas
+- **THEN** an inline text input appears at the click position
+
+#### Scenario: Confirming text
+- **WHEN** user presses Enter or clicks away from the text input
+- **THEN** the typed text becomes a permanent DrawObject::Text on the canvas using the active colour
+
+### Requirement: Text uses active colour and configurable size
+The system SHALL render text in the active stroke colour. Font size SHALL use the current stroke width as a scaling factor (e.g., width * 6 for font size).
+
+#### Scenario: Text colour matches active colour
+- **WHEN** user selects red from palette and adds text
+- **THEN** the text renders in red
+
+### Requirement: Text tool button in footer
+The system SHALL include a text tool button in the footer toolbar.
+
+#### Scenario: Switching to text tool
+- **WHEN** user clicks the text tool button
+- **THEN** the active tool changes to Text
+
+### Requirement: Select and move text
+Text objects SHALL be selectable and movable via the selection tool, like any other DrawObject.
+
+#### Scenario: Moving text with selection tool
+- **WHEN** selection tool is active and user drags a text object
+- **THEN** the text moves to the new position

--- a/openspec/changes/whiteboard-features/specs/theme-switching/spec.md
+++ b/openspec/changes/whiteboard-features/specs/theme-switching/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Detect OS theme on startup
+The system SHALL detect the OS theme (dark or light) on startup using the dark-light crate and apply matching egui Visuals.
+
+#### Scenario: Dark mode OS
+- **WHEN** the application starts on a system with dark mode enabled
+- **THEN** egui uses `Visuals::dark()` styling
+
+#### Scenario: Light mode OS
+- **WHEN** the application starts on a system with light mode enabled
+- **THEN** egui uses `Visuals::light()` styling
+
+### Requirement: Manual theme toggle
+The system SHALL provide a theme toggle button in the header to switch between dark and light mode at runtime.
+
+#### Scenario: Toggling theme
+- **WHEN** user clicks the theme toggle button
+- **THEN** the UI switches between dark and light visuals immediately
+
+### Requirement: Theme preference persists in session
+The system SHALL remember the user's theme choice for the duration of the session.
+
+#### Scenario: Theme stays after toggle
+- **WHEN** user toggles to light mode
+- **THEN** the UI remains in light mode until toggled again or the app is restarted

--- a/openspec/changes/whiteboard-features/specs/undo-redo/spec.md
+++ b/openspec/changes/whiteboard-features/specs/undo-redo/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Undo last action with Ctrl+Z
+The system SHALL undo the last canvas operation when Ctrl+Z is pressed. Undone operations SHALL be available for redo.
+
+#### Scenario: Undoing a drawn stroke
+- **WHEN** user draws a stroke and presses Ctrl+Z
+- **THEN** the stroke is removed from the canvas and the undo stack cursor moves back
+
+#### Scenario: Nothing to undo
+- **WHEN** user presses Ctrl+Z with an empty history
+- **THEN** nothing happens (no crash, no visual change)
+
+### Requirement: Redo with Ctrl+Y
+The system SHALL redo the last undone operation when Ctrl+Y is pressed.
+
+#### Scenario: Redoing an undone stroke
+- **WHEN** user undoes a stroke with Ctrl+Z then presses Ctrl+Y
+- **THEN** the stroke reappears on the canvas
+
+### Requirement: New action clears redo stack
+The system SHALL clear all redo entries when a new action is performed after an undo.
+
+#### Scenario: Drawing after undo
+- **WHEN** user undoes an action then draws a new stroke
+- **THEN** the undone action is no longer available for redo
+
+### Requirement: Undo/redo buttons in header
+The system SHALL display undo and redo buttons in the header toolbar as a secondary access method.
+
+#### Scenario: Clicking undo button
+- **WHEN** user clicks the undo button in the header
+- **THEN** the last action is undone, same as Ctrl+Z

--- a/openspec/changes/whiteboard-features/tasks.md
+++ b/openspec/changes/whiteboard-features/tasks.md
@@ -1,0 +1,97 @@
+## 1. Foundation — shared state and draw object model
+
+- [ ] 1.1 Create `state.rs` with `AppState` struct (active tool, active colour, stroke width, theme, objects list)
+- [ ] 1.2 Create `DrawObject` enum with variants: Freehand, Rectangle, Ellipse, Line, Arrow, Text, Image — each with per-object colour and width
+- [ ] 1.3 Create `Tool` enum: Freehand, Rectangle, Ellipse, Line, Arrow, Text, Eraser, Selection
+- [ ] 1.4 Refactor `main.rs` to create AppState and pass `&mut AppState` to all component render methods
+- [ ] 1.5 Refactor `canvas.rs` to use `Vec<DrawObject>` from AppState instead of local `Vec<Vec<Pos2>>`
+- [ ] 1.6 Refactor `footer.rs` to read/write AppState (active tool, colour, width) instead of `println!`
+
+## 2. Drawing colours
+
+- [ ] 2.1 Wire palette button clicks to set `app_state.active_colour`
+- [ ] 2.2 Add selected indicator (border highlight) on the active palette button
+- [ ] 2.3 Store active colour in each new DrawObject at creation time
+- [ ] 2.4 Render each DrawObject with its stored colour (not the global stroke)
+
+## 3. Line thickness
+
+- [ ] 3.1 Add thickness preset buttons (1px, 2px, 4px, 8px) to footer toolbar
+- [ ] 3.2 Wire thickness buttons to set `app_state.stroke_width`
+- [ ] 3.3 Add selected indicator on active thickness preset
+- [ ] 3.4 Store active width in each new DrawObject at creation time
+- [ ] 3.5 Render each DrawObject with its stored width
+
+## 4. Eraser
+
+- [ ] 4.1 Create `eraser.rs` module with hit-test-based erasure logic
+- [ ] 4.2 Implement distance-to-polyline hit-testing for Freehand strokes
+- [ ] 4.3 Implement bounding-rect hit-testing for shape DrawObjects
+- [ ] 4.4 Wire eraser button in footer to set active tool to Eraser
+- [ ] 4.5 Remove objects the pointer passes over when eraser is active
+- [ ] 4.6 Draw circle cursor showing erase radius
+
+## 5. Undo / Redo
+
+- [ ] 5.1 Create `history.rs` with Command enum (Add, Remove, Modify) and history stack with cursor
+- [ ] 5.2 Push Add commands when new DrawObjects are created
+- [ ] 5.3 Push Remove commands when objects are erased or deleted
+- [ ] 5.4 Implement undo (Ctrl+Z) — reverse last command
+- [ ] 5.5 Implement redo (Ctrl+Y) — replay next command
+- [ ] 5.6 Clear redo stack on new action after undo
+- [ ] 5.7 Add undo/redo buttons to header toolbar
+
+## 6. Shape tools
+
+- [ ] 6.1 Create `tools/shapes.rs` with shared click-drag-release input handling
+- [ ] 6.2 Implement rectangle tool — preview during drag, create DrawObject::Rectangle on release
+- [ ] 6.3 Implement ellipse tool — preview during drag, create DrawObject::Ellipse on release
+- [ ] 6.4 Implement straight line tool — preview during drag, create DrawObject::Line on release
+- [ ] 6.5 Implement arrow tool — line with arrowhead, preview during drag
+- [ ] 6.6 Add shape tool buttons (rect, ellipse, line, arrow) to footer toolbar
+
+## 7. Shape selection
+
+- [ ] 7.1 Create `tools/selection.rs` with selection state (selected object index)
+- [ ] 7.2 Implement click-to-select using hit-testing (reuse eraser hit-test logic)
+- [ ] 7.3 Render dashed bounding box around selected object
+- [ ] 7.4 Implement drag-to-move for selected objects (push Modify command to history)
+- [ ] 7.5 Implement Delete/Backspace to remove selected object
+- [ ] 7.6 Clear selection on click-on-empty or tool switch
+
+## 8. Screenshot capture
+
+- [ ] 8.1 Create `screenshot.rs` module wrapping xcap capture
+- [ ] 8.2 Implement minimise → capture → restore → load flow
+- [ ] 8.3 Convert xcap image to egui TextureHandle and create DrawObject::Image
+- [ ] 8.4 Add screenshot button to header toolbar
+- [ ] 8.5 Implement region selection overlay after capture (drag to crop)
+
+## 9. Dark/light theme
+
+- [ ] 9.1 Call `dark_light::detect()` on startup and set egui Visuals accordingly
+- [ ] 9.2 Add theme toggle button to header toolbar
+- [ ] 9.3 Store theme preference in AppState and apply on toggle
+
+## 10. Export to PNG
+
+- [ ] 10.1 Create `export.rs` module with canvas-to-image rendering
+- [ ] 10.2 Render all DrawObjects to a pixel buffer (ColorImage)
+- [ ] 10.3 Save pixel buffer as PNG using the image crate
+- [ ] 10.4 Add export button to header with file save dialog (rfd or native)
+- [ ] 10.5 Use current theme background colour for PNG background
+
+## 11. Text annotations
+
+- [ ] 11.1 Create `tools/text.rs` with text input state machine (placing → editing → committed)
+- [ ] 11.2 Show inline text input at click position when text tool is active
+- [ ] 11.3 Commit typed text as DrawObject::Text on Enter or click-away
+- [ ] 11.4 Render text using active colour with font size derived from stroke width
+- [ ] 11.5 Add text tool button to footer toolbar
+
+## 12. Clipboard
+
+- [ ] 12.1 Add `arboard` dependency to Cargo.toml
+- [ ] 12.2 Create `clipboard.rs` module wrapping arboard for image clipboard
+- [ ] 12.3 Implement Ctrl+C — render selection or full canvas to image, copy to clipboard
+- [ ] 12.4 Implement Ctrl+V — read clipboard image, create DrawObject::Image on canvas

--- a/openspec/research/architecture-analysis.md
+++ b/openspec/research/architecture-analysis.md
@@ -1,0 +1,273 @@
+# Architecture analysis for Snap feature development
+
+## Current data model and state management
+
+### Struct hierarchy
+```
+Snap (App)
+  ├── header: Header          — stateless, placeholder labels
+  ├── canvas: Canvas          — owns all drawing state
+  │     ├── lines: Vec<Vec<Pos2>>   — strokes in normalised 0..1 coords
+  │     └── stroke: Stroke          — current stroke style (width + colour)
+  └── footer: Footer          — owns toolbar UI state
+        ├── center_widget: Widget   — centering utility
+        └── palette: Palette        — 10 hardcoded Color32 values (fields color0..color9)
+```
+
+### Canvas data model (`canvas.rs`)
+- **Strokes** are stored as `Vec<Vec<Pos2>>` — each inner `Vec<Pos2>` is one continuous freehand line.
+- Points are in **normalised 0..1 coordinates** using `RectTransform::from_to` between a unit square (with `square_proportions()`) and screen space.
+- A new empty `Vec<Pos2>` is pushed when the pointer lifts (drag ends).
+- **Current stroke style**: a single `egui::Stroke` (width: `f32`, colour: `Color32`), initialised to `Stroke::new(1.0, Color32::from_rgb(25, 200, 100))`.
+- **All lines share the same stroke style** — there is no per-line colour/thickness. This is a major limitation for features 1-3.
+- The `ui_control` method renders an inline stroke editor (`ui.add(&mut self.stroke)`) and a "Clear Painting" button — but these are rendered *inside* the canvas panel, not connected to the footer.
+
+### Footer (`footer.rs`)
+- Renders 3 tool buttons, 10 palette colour buttons, and 1 eraser button.
+- **All button clicks just `println!()`** — nothing is connected to canvas state.
+- Tool buttons use emoji labels: pen, fountain pen, pencil.
+- Palette buttons call `self.palette.get_color(i)` for their fill colour.
+
+### Palette (`palette.rs`)
+- 10 individual `Color32` fields (`color0` through `color9`) — not an array.
+- `get_color(i: u8) -> Option<Color32>` with a 10-arm match statement.
+- Could be simplified to `[Color32; 10]` but works for now.
+
+### Header (`header.rs`)
+- Pure placeholder: 6 labels and a "test" label on the right.
+- Uses `egui::MenuBar::new().ui()` with left-to-right and right-to-left layouts.
+
+### Center widget (`center_widget.rs`)
+- Measures content width on one frame, applies centering margin on the next.
+- Used by footer to horizontally centre the toolbar.
+
+## Communication patterns (or lack thereof)
+
+**There is no shared state.** Each component owns its own state independently:
+- `Snap` holds `header`, `canvas`, `footer` as sibling fields.
+- `App::update` renders them in sequence but passes no shared context between them.
+- Footer buttons print to stdout instead of modifying any shared state.
+
+This is the **primary architectural gap** — we need a mechanism for footer tool/colour selection to flow into canvas drawing behaviour.
+
+## Key egui APIs needed for the 11 features
+
+### Feature 1: Colours (wire palette to canvas)
+- Already have `Color32` in palette and `Stroke` in canvas
+- Need: shared state for selected colour, apply to `canvas.stroke.color`
+
+### Feature 2: Eraser
+- `egui::Stroke` can use `Color32::TRANSPARENT` or we can remove points
+- Better approach: track eraser as a tool mode; on drag, remove lines that intersect the eraser path
+- Or simpler: draw with background colour (but this doesn't work on exported images cleanly)
+- Best: store an eraser flag per-stroke, render eraser strokes with blend mode or skip them
+
+### Feature 3: Line thickness
+- `egui::Stroke::width` is already an `f32`
+- `egui::Slider::new(value, range)` for thickness control
+- Or use preset thickness buttons in the footer
+
+### Feature 4: Shape selection (select + move shapes)
+- `egui::Sense::click_and_drag()` for selection
+- Need hit-testing against stored shapes
+- `Rect::contains(pos)` for bounding box checks
+- Transform selected shape's points by drag delta
+
+### Feature 5: Undo/Redo
+- Command pattern: store operations as a stack
+- Or simpler: snapshot `lines` vec on each stroke completion
+- `Vec<Vec<Vec<Pos2>>>` as history stack with cursor index
+- egui has no built-in undo system
+
+### Feature 6: Shape tools (rectangle, ellipse, arrow, line)
+- `egui::Shape::rect_stroke(rect, corner_radius, stroke)` — rectangles
+- `egui::Shape::ellipse_stroke(center, radius, stroke)` — ellipses
+- `egui::Shape::line_segment([p1, p2], stroke)` — straight lines
+- `egui::Shape::Path` for arrows (line + arrowhead)
+- `Painter::add(shape)` to render them
+- Need to extend data model beyond `Vec<Vec<Pos2>>` to support typed shapes
+
+### Feature 7: Screenshot capture
+- **`xcap` crate** (v0.8): `xcap::Monitor::all()` lists monitors, `monitor.capture_image()` returns `image::RgbaImage`
+- Need to convert `RgbaImage` -> `egui::ColorImage` -> `egui::TextureHandle` for display
+- `egui::ColorImage::from_rgba_unmultiplied(size, &pixels)` for conversion
+- `ctx.load_texture(name, image, options)` to create a texture
+- `ui.image(&texture)` or `Painter::image()` to render
+- **`global-hotkey` crate** (v0.7): register system-wide keyboard shortcuts
+  - `GlobalHotKeyManager::new()` — create manager
+  - `HotKey::new(modifiers, code)` — define a hotkey
+  - `manager.register(hotkey)` — register it
+  - `GlobalHotKeyEvent::receiver()` — poll for events
+  - Must be created/polled from the main thread
+  - Can poll in `App::update` each frame
+
+### Feature 8: Dark/light theme
+- **`dark-light` crate** (v2.0): `dark_light::detect()` returns `Mode::Dark | Mode::Light | Mode::Default`
+- egui has `Visuals::dark()` and `Visuals::light()` built-in
+- Apply via `ctx.set_visuals(Visuals::dark())` or `ctx.set_visuals(Visuals::light())`
+- Can detect once at startup and set accordingly
+- Optionally re-detect periodically or on focus
+
+### Feature 9: Export to PNG
+- **`image` crate** (v0.25): `image::RgbaImage::save("path.png")`
+- Need to render canvas to an offscreen buffer or capture the viewport
+- `eframe::Frame` doesn't expose framebuffer directly
+- Options:
+  1. Re-render all shapes to an `image::RgbaImage` manually (most reliable)
+  2. Use native file dialog via `rfd` crate (not yet a dependency)
+- For file picker: `rfd::FileDialog::new().add_filter("PNG", &["png"]).save_file()`
+- **Will need to add `rfd` as a dependency** for native file dialogs
+
+### Feature 10: Text annotations
+- `egui::TextEdit::singleline(&mut text)` or `multiline` for input
+- `Painter::text(pos, anchor, text, font_id, color)` for rendering text on canvas
+- Need a text tool mode: click to place, type text, press Enter to confirm
+- Store as a `TextAnnotation { position: Pos2, text: String, font_size: f32, color: Color32 }`
+
+### Feature 11: Clipboard copy/paste
+- `egui::Context` has no built-in image clipboard
+- Need platform-specific clipboard: `arboard` crate
+  - `arboard::Clipboard::new()` → `clipboard.set_image(ImageData { width, height, bytes })`
+  - `clipboard.get_image()` for paste
+- **Will need to add `arboard` as a dependency**
+- Keyboard shortcuts: `ctx.input(|i| i.key_pressed(Key::C) && i.modifiers.command)` for Ctrl+C/Cmd+C
+
+## Recommended approach for shared state
+
+### Introduce an `AppState` struct
+
+The most natural pattern for egui is a single shared state struct passed by mutable reference to all components:
+
+```rust
+pub struct AppState {
+    // Tool selection
+    pub active_tool: Tool,
+
+    // Drawing style
+    pub stroke_colour: Color32,
+    pub stroke_width: f32,
+
+    // Canvas data (moved from Canvas)
+    pub strokes: Vec<StrokeData>,
+    pub undo_stack: Vec<Vec<StrokeData>>,
+    pub redo_stack: Vec<Vec<StrokeData>>,
+
+    // Theme
+    pub theme: Theme,
+
+    // Screenshot
+    pub screenshot: Option<egui::TextureHandle>,
+}
+
+pub enum Tool {
+    Pen,
+    Highlighter,
+    Pencil,
+    Eraser,
+    Rectangle,
+    Ellipse,
+    Arrow,
+    Line,
+    Text,
+    Select,
+}
+
+pub struct StrokeData {
+    pub kind: StrokeKind,
+    pub colour: Color32,
+    pub width: f32,
+}
+
+pub enum StrokeKind {
+    Freehand(Vec<Pos2>),
+    Rectangle(Rect),
+    Ellipse { center: Pos2, radius: Vec2 },
+    Arrow { from: Pos2, to: Pos2 },
+    Line { from: Pos2, to: Pos2 },
+    Text { position: Pos2, text: String, font_size: f32 },
+}
+```
+
+### Threading model
+- `App::update` runs on the main thread every frame
+- Pass `&mut AppState` to each component's `render` method
+- Footer modifies `active_tool` and `stroke_colour`
+- Canvas reads `active_tool` to decide behaviour, reads `stroke_colour`/`stroke_width` for new strokes
+- No multi-threading needed for UI state
+
+### Trait changes
+Change `View::render` signature:
+```rust
+pub trait View {
+    fn render(&mut self, ui: &mut egui::Ui, state: &mut AppState);
+}
+```
+
+This is a **breaking change** to all components but is a small, mechanical refactor.
+
+## Architectural changes needed before features
+
+### 1. Introduce `AppState` (prerequisite for everything)
+- Create `state.rs` with shared `AppState`, `Tool`, `StrokeData`, `StrokeKind`
+- Update `View` trait to accept `&mut AppState`
+- Refactor `Snap::update` to create/pass `AppState`
+- Move drawing data from `Canvas` into `AppState`
+
+### 2. Refactor Canvas data model
+- Replace `Vec<Vec<Pos2>>` with `Vec<StrokeData>` — each stroke stores its own colour, width, and shape kind
+- This enables per-stroke colours, thickness, and multiple shape types
+- Keep normalised coordinate system
+
+### 3. Wire footer buttons to state
+- Footer reads/writes `state.active_tool` and `state.stroke_colour`
+- Show selected state visually (highlight active tool button, outline selected colour)
+
+### 4. Add new dependencies (for later features)
+- `rfd` — native file dialogs (export to PNG)
+- `arboard` — clipboard image support (copy/paste)
+
+### Recommended implementation order
+The features have natural dependencies. Recommended batching:
+
+**Batch 1 — Foundation (must be first)**
+1. `AppState` + `View` trait refactor
+2. Wire colours (feature 1)
+3. Wire eraser (feature 2)
+4. Line thickness (feature 3)
+
+**Batch 2 — Core drawing**
+5. Shape tools (feature 6)
+6. Text annotations (feature 10)
+7. Undo/Redo (feature 5)
+
+**Batch 3 — Platform integration**
+8. Dark/light theme (feature 8)
+9. Screenshot capture (feature 7)
+10. Export to PNG (feature 9)
+11. Clipboard copy/paste (feature 11)
+
+**Batch 4 — Advanced**
+12. Shape selection/move (feature 4) — hardest, depends on shapes existing
+
+## Notes on egui 0.33 specifics
+
+- `egui::Stroke` implements `Widget` — can be added directly to UI as an editor (colour picker + width slider). Canvas already uses this in `ui_control`.
+- `egui::color_picker::color_edit_button_srgba` — inline colour picker button
+- `Frame::canvas(style)` — creates a dark background frame for drawing areas
+- `Painter::extend(shapes)` — batch-add shapes (already used)
+- `Painter::rect_stroke`, `Painter::circle_stroke`, `Painter::line_segment` — shape primitives
+- `Painter::text` — text rendering with font selection
+- `Response::drag_delta()` — pixel delta during drag
+- `Response::drag_started()`, `drag_stopped()` — drag lifecycle
+- `Sense::drag()`, `Sense::click()`, `Sense::click_and_drag()` — interaction types
+- `ctx.input(|i| ...)` — read keyboard/mouse state
+- `ctx.request_repaint()` — force a redraw (useful for animations)
+
+## Risks and considerations
+
+1. **Coordinate system**: Normalised coords work for freehand but rectangles/ellipses need careful handling during resize. Store shapes in normalised coords too for consistency.
+2. **Performance**: With many strokes, rebuilding all shapes every frame could get slow. Consider caching the shape list and only rebuilding on change (egui redraws every frame regardless, but shape construction can be cached).
+3. **Eraser complexity**: True eraser (removing parts of strokes) is complex. Start with whole-stroke eraser (remove any stroke the eraser touches), upgrade later.
+4. **Text input in immediate mode**: egui's `TextEdit` needs careful state management — the text being edited must persist between frames. Store it in `AppState`.
+5. **Screenshot capture timing**: Need to hide the Snap window before capturing, then restore it. Use `ctx.send_viewport_cmd(ViewportCommand::Minimized(true))`, capture, then restore.
+6. **Global hotkeys**: `global-hotkey` must register from the main thread. Poll `GlobalHotKeyEvent::receiver()` in `App::update` each frame.


### PR DESCRIPTION
## Summary
- OpenSpec proposal, design, specs, and tasks for all 11 whiteboard features
- Architecture analysis from research phase
- Features: colours, eraser, line thickness, shape selection, undo/redo, shape tools, screenshot capture, dark/light theme, export PNG, text annotations, clipboard

## Test plan
- [ ] Review proposal.md for completeness
- [ ] Verify all 11 spec files have requirements and scenarios
- [ ] Confirm tasks.md has all implementation steps