### PR TITLE
feat: add dark/light theme switching

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,10 +1,20 @@
 use egui::Layout;
 
-pub struct Header {}
+pub struct Header {
+    /// Whether the theme toggle was clicked this frame
+    theme_toggled: bool,
+}
 
 impl Header {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            theme_toggled: false,
+        }
+    }
+
+    /// Returns true if the theme toggle button was clicked since the last call
+    pub fn take_theme_toggled(&mut self) -> bool {
+        std::mem::take(&mut self.theme_toggled)
     }
 }
 
@@ -29,7 +39,17 @@ impl super::View for Header {
             });
 
             ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.label("test");
+                let is_dark = ui.visuals().dark_mode;
+                // Show the icon for the opposite theme
+                let icon = if is_dark { "☀" } else { "🌙" };
+                let tooltip = if is_dark {
+                    "Switch to light theme"
+                } else {
+                    "Switch to dark theme"
+                };
+                if ui.button(icon).on_hover_text(tooltip).clicked() {
+                    self.theme_toggled = true;
+                }
             });
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ pub trait View {
 }
 
 struct Snap {
+    dark_mode: bool,
     header: header::Header,
     canvas: canvas::Canvas,
     footer: footer::Footer,
@@ -46,16 +47,35 @@ struct Snap {
 impl Snap {
     pub fn new() -> Self {
         Self {
+            dark_mode: true,
             footer: footer::Footer::new(),
             canvas: canvas::Canvas::new(),
             header: header::Header::new(),
         }
     }
 
-    pub fn init(self, cc: &CreationContext) -> Self {
+    pub fn init(mut self, cc: &CreationContext) -> Self {
         self.configure_fonts(&cc.egui_ctx);
+        self.dark_mode = self.detect_os_theme();
+        self.apply_theme(&cc.egui_ctx);
 
         self
+    }
+
+    fn detect_os_theme(&self) -> bool {
+        match dark_light::detect() {
+            Ok(dark_light::Mode::Light) => false,
+            // Default to dark for Dark, Unspecified, or detection errors
+            _ => true,
+        }
+    }
+
+    fn apply_theme(&self, ctx: &Context) {
+        if self.dark_mode {
+            ctx.set_visuals(egui::Visuals::dark());
+        } else {
+            ctx.set_visuals(egui::Visuals::light());
+        }
     }
 
     fn configure_fonts(&self, ctx: &Context) {
@@ -96,6 +116,11 @@ impl App for Snap {
                     self.header.render(ui);
                 })
             });
+
+        if self.header.take_theme_toggled() {
+            self.dark_mode = !self.dark_mode;
+            self.apply_theme(ctx);
+        }
 
         TopBottomPanel::bottom("bottom_panel")
             .exact_height(64.0)


### PR DESCRIPTION
## Summary

- Detect OS theme (dark/light) on startup using the `dark-light` crate and apply matching egui visuals
- Add theme toggle button to the header bar (sun icon in dark mode, moon icon in light mode)
- Toggle switches between `egui::Visuals::dark()` and `egui::Visuals::light()`
- Defaults to dark theme when OS preference is unspecified or detection fails

## Changes

- `src/main.rs`: Add `dark_mode: bool` to `Snap`, detect OS theme in `init()`, apply theme via `apply_theme()`, handle toggle in `update()`
- `src/header.rs`: Add theme toggle button in the right-aligned section of the menu bar, replacing placeholder label

## Test plan

- [ ] Verify app launches with correct theme matching OS preference
- [ ] Click theme toggle button and verify visuals switch between dark and light
- [ ] Verify button icon shows sun in dark mode, moon in light mode
- [ ] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test` all pass