### PR TITLE
feat: add shape drawing tools

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -26,6 +26,9 @@ impl Canvas {
             Tool::Eraser => {
                 self.handle_eraser_input(&response, state, &from_screen);
             }
+            Tool::Rectangle | Tool::Ellipse | Tool::Line | Tool::Arrow => {
+                self.handle_shape_input(&mut response, state, &from_screen);
+            }
             _ => {}
         }
 
@@ -45,6 +48,28 @@ impl Canvas {
                     screen_points,
                     Stroke::new(state.stroke_width, state.active_colour),
                 ));
+            }
+        }
+
+        // Render shape preview during drag
+        if let Some(start) = state.shape_start {
+            if let Some(pointer_pos) = response.hover_pos() {
+                let current = from_screen * pointer_pos;
+                let preview_colour = {
+                    let [r, g, b, _] = state.active_colour.to_array();
+                    Color32::from_rgba_unmultiplied(r, g, b, 160)
+                };
+                if let Some(preview) = self.build_shape_object(
+                    state.active_tool,
+                    start,
+                    current,
+                    preview_colour,
+                    state.stroke_width,
+                ) {
+                    if let Some(shape) = self.render_object(&preview, &to_screen) {
+                        painter.add(shape);
+                    }
+                }
             }
         }
 
@@ -101,6 +126,79 @@ impl Canvas {
             state
                 .objects
                 .retain(|obj| !eraser::hit_test(obj, canvas_pos));
+        }
+    }
+
+    fn handle_shape_input(
+        &self,
+        response: &mut Response,
+        state: &mut AppState,
+        from_screen: &emath::RectTransform,
+    ) {
+        if let Some(pointer_pos) = response.interact_pointer_pos() {
+            let canvas_pos = *from_screen * pointer_pos;
+            if state.shape_start.is_none() {
+                state.shape_start = Some(canvas_pos);
+            }
+            response.mark_changed();
+        } else if let Some(start) = state.shape_start.take() {
+            // Pointer released — commit the shape
+            if let Some(hover) = response.hover_pos() {
+                let end = *from_screen * hover;
+                if let Some(obj) = self.build_shape_object(
+                    state.active_tool,
+                    start,
+                    end,
+                    state.active_colour,
+                    state.stroke_width,
+                ) {
+                    state.objects.push(obj);
+                }
+            }
+            response.mark_changed();
+        }
+    }
+
+    fn build_shape_object(
+        &self,
+        tool: Tool,
+        start: Pos2,
+        end: Pos2,
+        colour: Color32,
+        width: f32,
+    ) -> Option<DrawObject> {
+        match tool {
+            Tool::Rectangle => Some(DrawObject::Rectangle {
+                min: Pos2::new(start.x.min(end.x), start.y.min(end.y)),
+                max: Pos2::new(start.x.max(end.x), start.y.max(end.y)),
+                colour,
+                width,
+            }),
+            Tool::Ellipse => {
+                let center = Pos2::new((start.x + end.x) / 2.0, (start.y + end.y) / 2.0);
+                let radius_x = (end.x - start.x).abs() / 2.0;
+                let radius_y = (end.y - start.y).abs() / 2.0;
+                Some(DrawObject::Ellipse {
+                    center,
+                    radius_x,
+                    radius_y,
+                    colour,
+                    width,
+                })
+            }
+            Tool::Line => Some(DrawObject::Line {
+                start,
+                end,
+                colour,
+                width,
+            }),
+            Tool::Arrow => Some(DrawObject::Arrow {
+                start,
+                end,
+                colour,
+                width,
+            }),
+            _ => None,
         }
     }
 

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -36,6 +36,42 @@ impl super::View for Footer {
                         state.active_tool = Tool::Freehand;
                     }
 
+                    // Rectangle tool
+                    let rect_btn = Button::new("\u{25ad}")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Rectangle))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(rect_btn).clicked() {
+                        state.active_tool = Tool::Rectangle;
+                    }
+
+                    // Ellipse tool
+                    let ellipse_btn = Button::new("\u{25cb}")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Ellipse))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(ellipse_btn).clicked() {
+                        state.active_tool = Tool::Ellipse;
+                    }
+
+                    // Line tool
+                    let line_btn = Button::new("\u{2571}")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Line))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(line_btn).clicked() {
+                        state.active_tool = Tool::Line;
+                    }
+
+                    // Arrow tool
+                    let arrow_btn = Button::new("\u{2192}")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Arrow))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(arrow_btn).clicked() {
+                        state.active_tool = Tool::Arrow;
+                    }
+
                     ui.separator();
 
                     // Colour palette buttons

--- a/src/state.rs
+++ b/src/state.rs
@@ -68,6 +68,8 @@ pub struct AppState {
     pub objects: Vec<DrawObject>,
     /// The freehand stroke currently being drawn (not yet committed to objects).
     pub current_stroke: Option<Vec<Pos2>>,
+    /// Drag start position (normalised 0..1) for shape tools.
+    pub shape_start: Option<Pos2>,
 }
 
 impl Default for AppState {
@@ -78,6 +80,7 @@ impl Default for AppState {
             stroke_width: 2.0,
             objects: Vec::new(),
             current_stroke: None,
+            shape_start: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add drag-to-draw interaction for rectangle, ellipse, line, and arrow tools
- Show semi-transparent preview shapes during drag, committed on pointer release
- Store all shapes in normalised 0-1 coordinates matching the existing freehand pattern
- Add toolbar buttons with unicode icons in the footer

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (4 tests)