### PR TITLE
feat: add clipboard copy/paste support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
 name = "snap"
 version = "0.1.4"
 dependencies = [
+ "arboard",
  "dark-light",
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/webbertakken/snap"
 serde = ["dep:serde", "dep:serde_json", "egui/serde"]
 
 [dependencies]
+arboard = "3"
 dark-light = "2.0.0"
 eframe = "0.33.3"
 egui = "0.33.3"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -3,15 +3,21 @@ use egui::*;
 use crate::eraser;
 use crate::state::{AppState, DrawObject, Tool};
 
-pub struct Canvas;
+pub struct Canvas {
+    /// Tracks the last canvas rect for clipboard copy.
+    last_canvas_rect: Option<Rect>,
+}
 
 impl Canvas {
     pub fn new() -> Self {
-        Self
+        Self {
+            last_canvas_rect: None,
+        }
     }
 
-    fn ui_content(&self, ui: &mut Ui, state: &mut AppState) -> egui::Response {
+    fn ui_content(&mut self, ui: &mut Ui, state: &mut AppState) -> egui::Response {
         let (mut response, painter) = ui.allocate_painter(ui.available_size(), Sense::drag());
+        self.last_canvas_rect = Some(response.rect);
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.square_proportions()),
@@ -182,9 +188,26 @@ impl Canvas {
                     Shape::line_segment([b, tip2], stroke),
                 ]))
             }
-            // Text and Image rendering are placeholder stubs
-            DrawObject::Text { .. } | DrawObject::Image { .. } => None,
+            DrawObject::Text { .. } => None,
+            DrawObject::Image { pos, size, texture } => {
+                let screen_pos = *to_screen * *pos;
+                let scale = to_screen.to().size();
+                let proportions = to_screen.from().size();
+                let sx = scale.x / proportions.x;
+                let sy = scale.y / proportions.y;
+                let screen_size = Vec2::new(size.x * sx, size.y * sy);
+                let rect = Rect::from_min_size(screen_pos, screen_size);
+                let uv = Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0));
+                Some(Shape::image(texture.id(), rect, uv, Color32::WHITE))
+            }
         }
+    }
+}
+
+impl Canvas {
+    /// Returns the last known canvas rect in screen coordinates.
+    pub fn canvas_rect(&self) -> Option<Rect> {
+        self.last_canvas_rect
     }
 }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,28 @@
+use arboard::{Clipboard, ImageData};
+
+/// Copies RGBA image data to the system clipboard.
+pub fn copy_to_clipboard(image_data: &[u8], width: usize, height: usize) {
+    let Ok(mut clipboard) = Clipboard::new() else {
+        #[cfg(debug_assertions)]
+        eprintln!("clipboard: failed to open clipboard");
+        return;
+    };
+
+    let img = ImageData {
+        width,
+        height,
+        bytes: std::borrow::Cow::Borrowed(image_data),
+    };
+
+    if let Err(_err) = clipboard.set_image(img) {
+        #[cfg(debug_assertions)]
+        eprintln!("clipboard: failed to set image: {_err}");
+    }
+}
+
+/// Reads an image from the system clipboard, returning RGBA bytes, width, and height.
+pub fn paste_from_clipboard() -> Option<(Vec<u8>, usize, usize)> {
+    let mut clipboard = Clipboard::new().ok()?;
+    let img = clipboard.get_image().ok()?;
+    Some((img.bytes.into_owned(), img.width, img.height))
+}

--- a/src/eraser.rs
+++ b/src/eraser.rs
@@ -45,7 +45,9 @@ pub fn hit_test(object: &DrawObject, pos: Pos2) -> bool {
             let rect = egui::Rect::from_min_size(*text_pos, egui::vec2(size, size));
             rect.expand(ERASER_TOLERANCE).contains(pos)
         }
-        DrawObject::Image { pos: img_pos, size } => {
+        DrawObject::Image {
+            pos: img_pos, size, ..
+        } => {
             let rect = egui::Rect::from_min_size(*img_pos, *size);
             rect.expand(ERASER_TOLERANCE).contains(pos)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use egui::{
 
 mod canvas;
 mod center_widget;
+mod clipboard;
 mod eraser;
 mod footer;
 mod header;
@@ -112,6 +113,16 @@ impl Snap {
 
 impl App for Snap {
     fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
+        // Ctrl+C: copy canvas region to clipboard
+        if ctx.input(|i| i.key_pressed(egui::Key::C) && i.modifiers.command) {
+            self.copy_canvas_to_clipboard();
+        }
+
+        // Ctrl+V: paste image from clipboard
+        if ctx.input(|i| i.key_pressed(egui::Key::V) && i.modifiers.command) {
+            self.paste_image_from_clipboard(ctx);
+        }
+
         TopBottomPanel::top("top_panel")
             .exact_height(64.0)
             .show_separator_line(false)
@@ -141,5 +152,85 @@ impl App for Snap {
             .show(ctx, |ui| ui.label("left"));
 
         CentralPanel::default().show(ctx, |ui| self.canvas.render(ui, &mut self.state));
+    }
+}
+
+impl Snap {
+    /// Captures the canvas area and copies it to the system clipboard.
+    fn copy_canvas_to_clipboard(&self) {
+        let Some(rect) = self.canvas.canvas_rect() else {
+            return;
+        };
+
+        // Use xcap to capture the canvas region
+        let monitors = match xcap::Monitor::all() {
+            Ok(m) => m,
+            Err(_err) => {
+                #[cfg(debug_assertions)]
+                eprintln!("clipboard copy: failed to list monitors: {_err}");
+                return;
+            }
+        };
+
+        let Some(monitor) = monitors.into_iter().next() else {
+            return;
+        };
+
+        let screenshot = match monitor.capture_image() {
+            Ok(img) => img,
+            Err(_err) => {
+                #[cfg(debug_assertions)]
+                eprintln!("clipboard copy: failed to capture screen: {_err}");
+                return;
+            }
+        };
+
+        // Crop to the canvas rect (screen coordinates)
+        let x = (rect.min.x as u32).min(screenshot.width().saturating_sub(1));
+        let y = (rect.min.y as u32).min(screenshot.height().saturating_sub(1));
+        let w = (rect.width() as u32).min(screenshot.width().saturating_sub(x));
+        let h = (rect.height() as u32).min(screenshot.height().saturating_sub(y));
+
+        if w == 0 || h == 0 {
+            return;
+        }
+
+        let cropped = image::imageops::crop_imm(&screenshot, x, y, w, h).to_image();
+        clipboard::copy_to_clipboard(cropped.as_raw(), w as usize, h as usize);
+    }
+
+    /// Reads an image from the clipboard and adds it as a DrawObject at the canvas centre.
+    fn paste_image_from_clipboard(&mut self, ctx: &Context) {
+        let Some((rgba, width, height)) = clipboard::paste_from_clipboard() else {
+            return;
+        };
+
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let color_image = egui::ColorImage::from_rgba_unmultiplied([width, height], &rgba);
+        let texture =
+            ctx.load_texture("clipboard_paste", color_image, egui::TextureOptions::LINEAR);
+
+        // Place image centred in the canvas using normalised coordinates.
+        // Use a sensible default size relative to the canvas (e.g. 0.4 of canvas width).
+        let canvas_rect = self.canvas.canvas_rect();
+        let (norm_pos, norm_size) = if let Some(rect) = canvas_rect {
+            let aspect = height as f32 / width as f32;
+            let norm_w = 0.4_f32; // 40% of canvas normalised width
+            let norm_h = norm_w * aspect * (rect.width() / rect.height());
+            let cx = 0.5 - norm_w / 2.0;
+            let cy = 0.5 - norm_h / 2.0;
+            (egui::pos2(cx, cy), egui::vec2(norm_w, norm_h))
+        } else {
+            (egui::pos2(0.3, 0.3), egui::vec2(0.4, 0.4))
+        };
+
+        self.state.objects.push(state::DrawObject::Image {
+            pos: norm_pos,
+            size: norm_size,
+            texture,
+        });
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Pos2};
+use egui::{Color32, Pos2, TextureHandle};
 
 /// All available drawing/interaction tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,7 +14,7 @@ pub enum Tool {
 }
 
 /// A single canvas element with its own visual properties.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum DrawObject {
     Freehand {
         /// Points in normalised 0..1 coordinates.
@@ -55,8 +55,11 @@ pub enum DrawObject {
         colour: Color32,
     },
     Image {
+        /// Position in normalised 0..1 coordinates.
         pos: Pos2,
+        /// Size in normalised coordinates.
         size: egui::Vec2,
+        texture: TextureHandle,
     },
 }
 


### PR DESCRIPTION
## Summary
- Add `arboard` dependency for cross-platform clipboard access
- New `clipboard.rs` module wrapping arboard for image copy/paste operations
- Ctrl+C captures canvas area via xcap and copies RGBA image to system clipboard
- Ctrl+V reads image from clipboard, loads as egui texture, and places centred on canvas
- `DrawObject::Image` now holds a `TextureHandle` for rendering pasted images
- Errors handled gracefully (silent in release, `eprintln!` in debug)

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (4/4 tests)
- [ ] Manual: copy an image to clipboard, paste into Snap canvas, verify it renders centred
- [ ] Manual: draw on canvas, Ctrl+C, paste into another app, verify image
- [ ] Manual: Ctrl+V with no image in clipboard does nothing (no crash)