### PR TITLE
feat: add text annotations tool

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,7 +1,7 @@
 use egui::*;
 
 use crate::eraser;
-use crate::state::{AppState, DrawObject, Tool};
+use crate::state::{AppState, DrawObject, TextEdit, Tool};
 
 pub struct Canvas;
 
@@ -11,7 +11,8 @@ impl Canvas {
     }
 
     fn ui_content(&self, ui: &mut Ui, state: &mut AppState) -> egui::Response {
-        let (mut response, painter) = ui.allocate_painter(ui.available_size(), Sense::drag());
+        let (mut response, painter) =
+            ui.allocate_painter(ui.available_size(), Sense::click_and_drag());
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.square_proportions()),
@@ -26,16 +27,16 @@ impl Canvas {
             Tool::Eraser => {
                 self.handle_eraser_input(&response, state, &from_screen);
             }
+            Tool::Text => {
+                Self::handle_text_click(&response, state, &from_screen);
+            }
             _ => {}
         }
 
         // Render all committed objects
-        let shapes: Vec<Shape> = state
-            .objects
-            .iter()
-            .filter_map(|obj| self.render_object(obj, &to_screen))
-            .collect();
-        painter.extend(shapes);
+        for obj in &state.objects {
+            self.render_object(obj, &to_screen, &painter);
+        }
 
         // Render the in-progress stroke
         if let Some(ref points) = state.current_stroke {
@@ -47,6 +48,9 @@ impl Canvas {
                 ));
             }
         }
+
+        // Render inline text editor
+        Self::render_text_editor(ui, state, &to_screen, &from_screen);
 
         // Draw eraser cursor
         if state.active_tool == Tool::Eraser {
@@ -104,18 +108,130 @@ impl Canvas {
         }
     }
 
-    fn render_object(&self, obj: &DrawObject, to_screen: &emath::RectTransform) -> Option<Shape> {
+    /// When the text tool is active, a click on the canvas starts a new text edit
+    /// (committing any existing in-progress text first).
+    fn handle_text_click(
+        response: &Response,
+        state: &mut AppState,
+        from_screen: &emath::RectTransform,
+    ) {
+        if response.clicked() {
+            if let Some(pointer_pos) = response.interact_pointer_pos() {
+                // Commit any existing in-progress text before starting a new one
+                Self::commit_editing_text(state);
+
+                let canvas_pos = *from_screen * pointer_pos;
+                state.editing_text = Some(TextEdit {
+                    position: canvas_pos,
+                    content: String::new(),
+                    colour: state.active_colour,
+                    font_size: state.stroke_width * 6.0,
+                });
+            }
+        }
+    }
+
+    /// Render the inline text editor widget at the editing position.
+    fn render_text_editor(
+        ui: &mut Ui,
+        state: &mut AppState,
+        to_screen: &emath::RectTransform,
+        from_screen: &emath::RectTransform,
+    ) {
+        // Take editing_text out to avoid borrow conflicts
+        let Some(mut editing) = state.editing_text.take() else {
+            return;
+        };
+
+        let screen_pos = *to_screen * editing.position;
+        let text_edit_id = Id::new("canvas_text_edit");
+
+        let area_response = Area::new(text_edit_id)
+            .fixed_pos(screen_pos)
+            .order(Order::Foreground)
+            .show(ui.ctx(), |ui| {
+                let te = egui::TextEdit::singleline(&mut editing.content)
+                    .font(FontId::proportional(editing.font_size))
+                    .text_color(editing.colour)
+                    .frame(false)
+                    .desired_width(200.0)
+                    .cursor_at_end(true);
+                let te_response = ui.add(te);
+
+                // Request focus on first frame
+                if editing.content.is_empty() {
+                    te_response.request_focus();
+                }
+
+                te_response
+            });
+
+        let te_response = area_response.inner;
+
+        // Commit on Enter or Escape
+        let enter_pressed = ui.input(|i| i.key_pressed(Key::Enter));
+        let escape_pressed = ui.input(|i| i.key_pressed(Key::Escape));
+
+        // Commit on click-away: the text edit lost focus and a click happened elsewhere
+        let clicked_away = te_response.lost_focus()
+            && ui.input(|i| i.pointer.any_click())
+            && !te_response.contains_pointer();
+
+        // Also check if a click happened outside the text edit area on the canvas
+        let clicked_canvas_elsewhere =
+            if let Some(click_pos) = ui.input(|i| i.pointer.press_origin()) {
+                let canvas_click = *from_screen * click_pos;
+                // Only if this is a new click, not the original placement click
+                !editing.content.is_empty()
+                    && ui.input(|i| i.pointer.any_pressed())
+                    && canvas_click != editing.position
+                    && !area_response.response.rect.contains(click_pos)
+            } else {
+                false
+            };
+
+        if enter_pressed || escape_pressed || clicked_away || clicked_canvas_elsewhere {
+            // Commit non-empty text
+            if !editing.content.trim().is_empty() {
+                state.objects.push(DrawObject::Text {
+                    pos: editing.position,
+                    content: editing.content,
+                    font_size: editing.font_size,
+                    colour: editing.colour,
+                });
+            }
+            // editing_text stays None (we already took it out)
+        } else {
+            // Keep editing
+            state.editing_text = Some(editing);
+        }
+    }
+
+    /// Commit any in-progress text edit to the objects list.
+    fn commit_editing_text(state: &mut AppState) {
+        if let Some(editing) = state.editing_text.take() {
+            if !editing.content.trim().is_empty() {
+                state.objects.push(DrawObject::Text {
+                    pos: editing.position,
+                    content: editing.content,
+                    font_size: editing.font_size,
+                    colour: editing.colour,
+                });
+            }
+        }
+    }
+
+    fn render_object(&self, obj: &DrawObject, to_screen: &emath::RectTransform, painter: &Painter) {
         match obj {
             DrawObject::Freehand {
                 points,
                 colour,
                 width,
             } => {
-                if points.len() < 2 {
-                    return None;
+                if points.len() >= 2 {
+                    let screen_points: Vec<Pos2> = points.iter().map(|p| *to_screen * *p).collect();
+                    painter.add(Shape::line(screen_points, Stroke::new(*width, *colour)));
                 }
-                let screen_points: Vec<Pos2> = points.iter().map(|p| *to_screen * *p).collect();
-                Some(Shape::line(screen_points, Stroke::new(*width, *colour)))
             }
             DrawObject::Rectangle {
                 min,
@@ -125,12 +241,12 @@ impl Canvas {
             } => {
                 let screen_min = *to_screen * *min;
                 let screen_max = *to_screen * *max;
-                Some(Shape::rect_stroke(
+                painter.add(Shape::rect_stroke(
                     Rect::from_min_max(screen_min, screen_max),
                     CornerRadius::ZERO,
                     Stroke::new(*width, *colour),
                     StrokeKind::Outside,
-                ))
+                ));
             }
             DrawObject::Ellipse {
                 center,
@@ -140,16 +256,15 @@ impl Canvas {
                 width,
             } => {
                 let screen_center = *to_screen * *center;
-                // Scale radii from normalised to screen space
                 let scale = to_screen.to().size();
                 let proportions = to_screen.from().size();
                 let sx = scale.x / proportions.x;
                 let sy = scale.y / proportions.y;
-                Some(Shape::ellipse_stroke(
+                painter.add(Shape::ellipse_stroke(
                     screen_center,
                     Vec2::new(radius_x * sx, radius_y * sy),
                     Stroke::new(*width, *colour),
-                ))
+                ));
             }
             DrawObject::Line {
                 start,
@@ -159,7 +274,7 @@ impl Canvas {
             } => {
                 let a = *to_screen * *start;
                 let b = *to_screen * *end;
-                Some(Shape::line_segment([a, b], Stroke::new(*width, *colour)))
+                painter.add(Shape::line_segment([a, b], Stroke::new(*width, *colour)));
             }
             DrawObject::Arrow {
                 start,
@@ -169,21 +284,34 @@ impl Canvas {
             } => {
                 let a = *to_screen * *start;
                 let b = *to_screen * *end;
-                // Simple arrow: line + arrowhead lines
                 let dir = (b - a).normalized();
                 let perp = Vec2::new(-dir.y, dir.x);
                 let arrow_len = 10.0;
                 let tip1 = b - arrow_len * dir + arrow_len * 0.4 * perp;
                 let tip2 = b - arrow_len * dir - arrow_len * 0.4 * perp;
                 let stroke = Stroke::new(*width, *colour);
-                Some(Shape::Vec(vec![
+                painter.add(Shape::Vec(vec![
                     Shape::line_segment([a, b], stroke),
                     Shape::line_segment([b, tip1], stroke),
                     Shape::line_segment([b, tip2], stroke),
-                ]))
+                ]));
             }
-            // Text and Image rendering are placeholder stubs
-            DrawObject::Text { .. } | DrawObject::Image { .. } => None,
+            DrawObject::Text {
+                pos,
+                content,
+                font_size,
+                colour,
+            } => {
+                let screen_pos = *to_screen * *pos;
+                painter.text(
+                    screen_pos,
+                    Align2::LEFT_TOP,
+                    content,
+                    FontId::proportional(*font_size),
+                    *colour,
+                );
+            }
+            DrawObject::Image { .. } => {}
         }
     }
 }

--- a/src/eraser.rs
+++ b/src/eraser.rs
@@ -39,10 +39,18 @@ pub fn hit_test(object: &DrawObject, pos: Pos2) -> bool {
         DrawObject::Line { start, end, .. } | DrawObject::Arrow { start, end, .. } => {
             distance_to_segment(pos, *start, *end) < ERASER_TOLERANCE
         }
-        DrawObject::Text { pos: text_pos, .. } => {
-            // Simple bounding-box approximation
-            let size = 0.05; // rough text bounding size in normalised coords
-            let rect = egui::Rect::from_min_size(*text_pos, egui::vec2(size, size));
+        DrawObject::Text {
+            pos: text_pos,
+            content,
+            font_size,
+            ..
+        } => {
+            // Approximate bounding box using character count and font size in normalised coords.
+            // font_size is in screen pixels; a rough normalised equivalent is font_size * 0.001.
+            let char_width = *font_size * 0.0006;
+            let line_height = *font_size * 0.001;
+            let width = char_width * content.len().max(1) as f32;
+            let rect = egui::Rect::from_min_size(*text_pos, egui::vec2(width, line_height));
             rect.expand(ERASER_TOLERANCE).contains(pos)
         }
         DrawObject::Image { pos: img_pos, size } => {

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -78,6 +78,15 @@ impl super::View for Footer {
 
                     ui.separator();
 
+                    // Text tool button
+                    let text_btn = Button::new("T")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Text))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(text_btn).clicked() {
+                        state.active_tool = Tool::Text;
+                    }
+
                     // Eraser button
                     let eraser_btn = Button::new("E")
                         .fill(Color32::from_gray(8))

--- a/src/state.rs
+++ b/src/state.rs
@@ -60,6 +60,19 @@ pub enum DrawObject {
     },
 }
 
+/// In-progress text being edited on the canvas.
+#[derive(Debug, Clone)]
+pub struct TextEdit {
+    /// Position in normalised 0..1 coordinates.
+    pub position: Pos2,
+    /// The text content being typed.
+    pub content: String,
+    /// Colour captured when editing started.
+    pub colour: Color32,
+    /// Font size captured when editing started.
+    pub font_size: f32,
+}
+
 /// Shared application state passed to all components each frame.
 pub struct AppState {
     pub active_tool: Tool,
@@ -68,6 +81,8 @@ pub struct AppState {
     pub objects: Vec<DrawObject>,
     /// The freehand stroke currently being drawn (not yet committed to objects).
     pub current_stroke: Option<Vec<Pos2>>,
+    /// Text annotation currently being edited on the canvas.
+    pub editing_text: Option<TextEdit>,
 }
 
 impl Default for AppState {
@@ -78,6 +93,7 @@ impl Default for AppState {
             stroke_width: 2.0,
             objects: Vec::new(),
             current_stroke: None,
+            editing_text: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add text tool: click canvas to place inline text input, press Enter/Escape/click-away to commit
- Text objects render on canvas using `painter.text()` with stored colour and font size
- Font size scales with stroke width (`stroke_width * 6.0`)
- "T" button in footer toolbar to activate text tool
- Eraser hit test uses font-size-aware bounding box for text objects
- All coordinates stored in normalised 0-1 space

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (4 tests)
- [ ] Manual: select text tool, click canvas, type text, press Enter — text appears
- [ ] Manual: eraser removes text objects