### PR TITLE
feat: add export to PNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1096,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
 dependencies = [
- "ashpd",
+ "ashpd 0.10.3",
  "async-std",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3319,6 +3341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3694,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd 0.11.1",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +4003,7 @@ dependencies = [
  "egui",
  "global-hotkey",
  "image",
+ "rfd",
  "serde",
  "serde_json",
  "xcap",
@@ -4280,6 +4333,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ global-hotkey = "0.7.0"
 image = "0.25"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+rfd = "0.15"
 xcap = "0.8"
 
 # cargo-dist build profile

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,330 @@
+use std::path::Path;
+
+use egui::{Color32, Pos2};
+use image::{ImageBuffer, Rgba, RgbaImage};
+
+use crate::state::DrawObject;
+
+/// Renders all draw objects to a PNG file at the given path.
+///
+/// Objects are stored in normalised 0..1 coordinates (with square proportions).
+/// We map them into a `width x height` pixel buffer, matching egui's
+/// `RectTransform::from_to(Rect(0..proportions), Rect(0..size))` logic.
+pub fn export_png(
+    objects: &[DrawObject],
+    width: u32,
+    height: u32,
+    background: Color32,
+    path: &Path,
+) -> Result<(), String> {
+    let mut img: RgbaImage = ImageBuffer::from_pixel(
+        width,
+        height,
+        Rgba([
+            background.r(),
+            background.g(),
+            background.b(),
+            background.a(),
+        ]),
+    );
+
+    // Compute the same square-proportions scaling that canvas.rs uses.
+    let (fw, fh) = square_proportions(width as f32, height as f32);
+
+    for obj in objects {
+        render_object(&mut img, obj, width as f32, height as f32, fw, fh);
+    }
+
+    img.save(path)
+        .map_err(|e| format!("Failed to save PNG: {e}"))
+}
+
+/// Mirrors `egui::Vec2::square_proportions` — returns (px, py) where the
+/// shorter side is 1.0 and the longer side is > 1.0.
+fn square_proportions(w: f32, h: f32) -> (f32, f32) {
+    if w >= h {
+        (w / h, 1.0)
+    } else {
+        (1.0, h / w)
+    }
+}
+
+/// Converts a normalised coordinate to pixel space, matching egui's RectTransform.
+fn to_pixel(p: Pos2, img_w: f32, img_h: f32, prop_w: f32, prop_h: f32) -> (f32, f32) {
+    let x = p.x / prop_w * img_w;
+    let y = p.y / prop_h * img_h;
+    (x, y)
+}
+
+fn render_object(
+    img: &mut RgbaImage,
+    obj: &DrawObject,
+    img_w: f32,
+    img_h: f32,
+    prop_w: f32,
+    prop_h: f32,
+) {
+    match obj {
+        DrawObject::Freehand {
+            points,
+            colour,
+            width,
+        } => {
+            if points.len() < 2 {
+                return;
+            }
+            let rgba = colour_to_rgba(*colour);
+            let half = (*width / 2.0).max(0.5);
+            for pair in points.windows(2) {
+                let (x0, y0) = to_pixel(pair[0], img_w, img_h, prop_w, prop_h);
+                let (x1, y1) = to_pixel(pair[1], img_w, img_h, prop_w, prop_h);
+                draw_thick_line(img, x0, y0, x1, y1, half, rgba);
+            }
+        }
+        DrawObject::Rectangle {
+            min,
+            max,
+            colour,
+            width,
+        } => {
+            let (x0, y0) = to_pixel(*min, img_w, img_h, prop_w, prop_h);
+            let (x1, y1) = to_pixel(*max, img_w, img_h, prop_w, prop_h);
+            let rgba = colour_to_rgba(*colour);
+            let half = (*width / 2.0).max(0.5);
+            // Four edges
+            draw_thick_line(img, x0, y0, x1, y0, half, rgba);
+            draw_thick_line(img, x1, y0, x1, y1, half, rgba);
+            draw_thick_line(img, x1, y1, x0, y1, half, rgba);
+            draw_thick_line(img, x0, y1, x0, y0, half, rgba);
+        }
+        DrawObject::Ellipse {
+            center,
+            radius_x,
+            radius_y,
+            colour,
+            width,
+        } => {
+            let (cx, cy) = to_pixel(*center, img_w, img_h, prop_w, prop_h);
+            let sx = img_w / prop_w;
+            let sy = img_h / prop_h;
+            let rx = radius_x * sx;
+            let ry = radius_y * sy;
+            let rgba = colour_to_rgba(*colour);
+            let half = (*width / 2.0).max(0.5);
+            draw_ellipse_outline(img, cx, cy, rx, ry, half, rgba);
+        }
+        DrawObject::Line {
+            start,
+            end,
+            colour,
+            width,
+        } => {
+            let (x0, y0) = to_pixel(*start, img_w, img_h, prop_w, prop_h);
+            let (x1, y1) = to_pixel(*end, img_w, img_h, prop_w, prop_h);
+            let rgba = colour_to_rgba(*colour);
+            let half = (*width / 2.0).max(0.5);
+            draw_thick_line(img, x0, y0, x1, y1, half, rgba);
+        }
+        DrawObject::Arrow {
+            start,
+            end,
+            colour,
+            width,
+        } => {
+            let (ax, ay) = to_pixel(*start, img_w, img_h, prop_w, prop_h);
+            let (bx, by) = to_pixel(*end, img_w, img_h, prop_w, prop_h);
+            let rgba = colour_to_rgba(*colour);
+            let half = (*width / 2.0).max(0.5);
+            draw_thick_line(img, ax, ay, bx, by, half, rgba);
+
+            // Arrowhead — mirrors canvas.rs logic
+            let dx = bx - ax;
+            let dy = by - ay;
+            let len = (dx * dx + dy * dy).sqrt();
+            if len > 0.0 {
+                let dir_x = dx / len;
+                let dir_y = dy / len;
+                let perp_x = -dir_y;
+                let perp_y = dir_x;
+                let arrow_len = 10.0_f32;
+                let tip1_x = bx - arrow_len * dir_x + arrow_len * 0.4 * perp_x;
+                let tip1_y = by - arrow_len * dir_y + arrow_len * 0.4 * perp_y;
+                let tip2_x = bx - arrow_len * dir_x - arrow_len * 0.4 * perp_x;
+                let tip2_y = by - arrow_len * dir_y - arrow_len * 0.4 * perp_y;
+                draw_thick_line(img, bx, by, tip1_x, tip1_y, half, rgba);
+                draw_thick_line(img, bx, by, tip2_x, tip2_y, half, rgba);
+            }
+        }
+        // Text and Image rendering are not yet fully supported; skip silently.
+        DrawObject::Text { .. } | DrawObject::Image { .. } => {}
+    }
+}
+
+fn colour_to_rgba(c: Color32) -> Rgba<u8> {
+    Rgba([c.r(), c.g(), c.b(), c.a()])
+}
+
+/// Draws a line with thickness using Bresenham, filling a circle of `half_w` at each step.
+fn draw_thick_line(
+    img: &mut RgbaImage,
+    x0: f32,
+    y0: f32,
+    x1: f32,
+    y1: f32,
+    half_w: f32,
+    colour: Rgba<u8>,
+) {
+    let dx = x1 - x0;
+    let dy = y1 - y0;
+    let dist = (dx * dx + dy * dy).sqrt();
+    let steps = (dist * 2.0).max(1.0) as u32;
+
+    for i in 0..=steps {
+        let t = i as f32 / steps as f32;
+        let px = x0 + dx * t;
+        let py = y0 + dy * t;
+        fill_circle(img, px, py, half_w, colour);
+    }
+}
+
+/// Fills a circle of given radius at (cx, cy) with the given colour, alpha-blending.
+fn fill_circle(img: &mut RgbaImage, cx: f32, cy: f32, radius: f32, colour: Rgba<u8>) {
+    let (w, h) = img.dimensions();
+    let r_ceil = radius.ceil() as i32;
+    let cx_i = cx as i32;
+    let cy_i = cy as i32;
+    let r_sq = radius * radius;
+
+    for dy in -r_ceil..=r_ceil {
+        for dx in -r_ceil..=r_ceil {
+            if (dx * dx + dy * dy) as f32 <= r_sq {
+                let px = cx_i + dx;
+                let py = cy_i + dy;
+                if px >= 0 && py >= 0 && (px as u32) < w && (py as u32) < h {
+                    blend_pixel(img, px as u32, py as u32, colour);
+                }
+            }
+        }
+    }
+}
+
+/// Alpha-blends `src` over the existing pixel at (x, y).
+fn blend_pixel(img: &mut RgbaImage, x: u32, y: u32, src: Rgba<u8>) {
+    let dst = img.get_pixel(x, y);
+    let sa = src[3] as f32 / 255.0;
+    let da = dst[3] as f32 / 255.0;
+    let out_a = sa + da * (1.0 - sa);
+    if out_a == 0.0 {
+        return;
+    }
+    let blend =
+        |s: u8, d: u8| -> u8 { ((s as f32 * sa + d as f32 * da * (1.0 - sa)) / out_a) as u8 };
+    *img.get_pixel_mut(x, y) = Rgba([
+        blend(src[0], dst[0]),
+        blend(src[1], dst[1]),
+        blend(src[2], dst[2]),
+        (out_a * 255.0) as u8,
+    ]);
+}
+
+/// Draws an ellipse outline by sampling points around the perimeter.
+fn draw_ellipse_outline(
+    img: &mut RgbaImage,
+    cx: f32,
+    cy: f32,
+    rx: f32,
+    ry: f32,
+    half_w: f32,
+    colour: Rgba<u8>,
+) {
+    let circumference =
+        std::f32::consts::PI * (3.0 * (rx + ry) - ((3.0 * rx + ry) * (rx + 3.0 * ry)).sqrt());
+    let steps = (circumference * 2.0).max(64.0) as u32;
+
+    let mut prev_x = cx + rx;
+    let mut prev_y = cy;
+
+    for i in 1..=steps {
+        let angle = 2.0 * std::f32::consts::PI * i as f32 / steps as f32;
+        let cur_x = cx + rx * angle.cos();
+        let cur_y = cy + ry * angle.sin();
+        draw_thick_line(img, prev_x, prev_y, cur_x, cur_y, half_w, colour);
+        prev_x = cur_x;
+        prev_y = cur_y;
+    }
+}
+
+/// Opens a native file-save dialog and exports the canvas to PNG.
+/// Returns `Ok(Some(path))` if saved, `Ok(None)` if the user cancelled.
+pub fn export_with_dialog(
+    objects: &[DrawObject],
+    canvas_width: u32,
+    canvas_height: u32,
+    background: Color32,
+) -> Result<Option<std::path::PathBuf>, String> {
+    let path = rfd::FileDialog::new()
+        .add_filter("PNG image", &["png"])
+        .set_file_name("snap-export.png")
+        .save_file();
+
+    match path {
+        Some(p) => {
+            export_png(objects, canvas_width, canvas_height, background, &p)?;
+            Ok(Some(p))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exports_empty_canvas() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("snap_test_empty.png");
+        let result = export_png(&[], 100, 100, Color32::WHITE, &path);
+        assert!(result.is_ok());
+        assert!(path.exists());
+        let img = image::open(&path).unwrap().to_rgba8();
+        assert_eq!(img.dimensions(), (100, 100));
+        // All pixels should be white
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn exports_freehand_stroke() {
+        let objects = vec![DrawObject::Freehand {
+            points: vec![Pos2::new(0.0, 0.5), Pos2::new(1.0, 0.5)],
+            colour: Color32::RED,
+            width: 2.0,
+        }];
+        let dir = std::env::temp_dir();
+        let path = dir.join("snap_test_freehand.png");
+        let result = export_png(&objects, 200, 200, Color32::WHITE, &path);
+        assert!(result.is_ok());
+        let img = image::open(&path).unwrap().to_rgba8();
+        // The midpoint of a horizontal line at y=0.5 should have red pixels
+        let mid = img.get_pixel(100, 100);
+        assert_eq!(mid[0], 255); // red channel
+        assert_eq!(mid[1], 0);
+        assert_eq!(mid[2], 0);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn square_proportions_landscape() {
+        let (pw, ph) = square_proportions(1600.0, 900.0);
+        assert!((pw - 1600.0 / 900.0).abs() < 0.001);
+        assert!((ph - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn square_proportions_portrait() {
+        let (pw, ph) = square_proportions(600.0, 800.0);
+        assert!((pw - 1.0).abs() < 0.001);
+        assert!((ph - 800.0 / 600.0).abs() < 0.001);
+    }
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -21,7 +21,7 @@ impl Header {
 }
 
 impl super::View for Header {
-    fn render(&mut self, ui: &mut egui::Ui, _state: &mut AppState) {
+    fn render(&mut self, ui: &mut egui::Ui, state: &mut AppState) {
         egui::MenuBar::new().ui(ui, |ui| {
             ui.with_layout(Layout::left_to_right(egui::Align::Center), |ui| {
                 ui.horizontal(|ui| {
@@ -51,6 +51,14 @@ impl super::View for Header {
                 };
                 if ui.button(icon).on_hover_text(tooltip).clicked() {
                     self.theme_toggled = true;
+                }
+
+                if ui
+                    .button("Export")
+                    .on_hover_text("Export canvas as PNG")
+                    .clicked()
+                {
+                    state.export_requested = true;
                 }
             });
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use egui::{
 mod canvas;
 mod center_widget;
 mod eraser;
+mod export;
 mod footer;
 mod header;
 mod palette;
@@ -124,6 +125,21 @@ impl App for Snap {
         if self.header.take_theme_toggled() {
             self.dark_mode = !self.dark_mode;
             self.apply_theme(ctx);
+        }
+
+        if std::mem::take(&mut self.state.export_requested) {
+            let bg = if self.dark_mode {
+                egui::Color32::from_gray(27) // egui dark background
+            } else {
+                egui::Color32::from_gray(248) // egui light background
+            };
+            // Use a sensible default canvas size for the export
+            let viewport = ctx.input(|i| i.viewport_rect());
+            let w = viewport.width().max(1.0) as u32;
+            let h = viewport.height().max(1.0) as u32;
+            if let Err(e) = export::export_with_dialog(&self.state.objects, w, h, bg) {
+                eprintln!("Export failed: {e}");
+            }
         }
 
         TopBottomPanel::bottom("bottom_panel")

--- a/src/state.rs
+++ b/src/state.rs
@@ -68,6 +68,8 @@ pub struct AppState {
     pub objects: Vec<DrawObject>,
     /// The freehand stroke currently being drawn (not yet committed to objects).
     pub current_stroke: Option<Vec<Pos2>>,
+    /// Set to true when the user clicks the export button; consumed by the app loop.
+    pub export_requested: bool,
 }
 
 impl Default for AppState {
@@ -78,6 +80,7 @@ impl Default for AppState {
             stroke_width: 2.0,
             objects: Vec::new(),
             current_stroke: None,
+            export_requested: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `rfd` crate (v0.15) for native file save dialogs
- Create `export.rs` module with software rendering of all DrawObject variants to an `image::RgbaImage`
- Add "Export" button to header toolbar that triggers file dialog and saves canvas as PNG
- Supports freehand, rectangle, ellipse, line, and arrow objects with correct coordinate mapping
- Unit tests for empty canvas export, freehand stroke export, and square proportions calculation

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 8 tests pass
- [ ] Manual: draw on canvas, click Export, verify PNG output matches canvas content