### PR TITLE
feat: add shape selection tool

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,6 +1,7 @@
 use egui::*;
 
 use crate::eraser;
+use crate::selection;
 use crate::state::{AppState, DrawObject, Tool};
 
 pub struct Canvas;
@@ -11,7 +12,12 @@ impl Canvas {
     }
 
     fn ui_content(&self, ui: &mut Ui, state: &mut AppState) -> egui::Response {
-        let (mut response, painter) = ui.allocate_painter(ui.available_size(), Sense::drag());
+        let sense = if state.active_tool == Tool::Selection {
+            Sense::click_and_drag()
+        } else {
+            Sense::drag()
+        };
+        let (mut response, painter) = ui.allocate_painter(ui.available_size(), sense);
 
         let to_screen = emath::RectTransform::from_to(
             Rect::from_min_size(Pos2::ZERO, response.rect.square_proportions()),
@@ -25,6 +31,9 @@ impl Canvas {
             }
             Tool::Eraser => {
                 self.handle_eraser_input(&response, state, &from_screen);
+            }
+            Tool::Selection => {
+                selection::handle_selection_input(&response, state, &from_screen, ui.ctx());
             }
             _ => {}
         }
@@ -46,6 +55,11 @@ impl Canvas {
                     Stroke::new(state.stroke_width, state.active_colour),
                 ));
             }
+        }
+
+        // Draw selection bounding box
+        if state.active_tool == Tool::Selection {
+            selection::draw_selection_box(&painter, state, &to_screen);
         }
 
         // Draw eraser cursor

--- a/src/eraser.rs
+++ b/src/eraser.rs
@@ -53,7 +53,7 @@ pub fn hit_test(object: &DrawObject, pos: Pos2) -> bool {
 }
 
 /// Minimum distance from a point to a polyline (sequence of connected segments).
-fn distance_to_polyline(point: Pos2, polyline: &[Pos2]) -> f32 {
+pub fn distance_to_polyline(point: Pos2, polyline: &[Pos2]) -> f32 {
     if polyline.is_empty() {
         return f32::MAX;
     }
@@ -68,7 +68,7 @@ fn distance_to_polyline(point: Pos2, polyline: &[Pos2]) -> f32 {
 }
 
 /// Minimum distance from a point to a line segment.
-fn distance_to_segment(point: Pos2, a: Pos2, b: Pos2) -> f32 {
+pub fn distance_to_segment(point: Pos2, a: Pos2, b: Pos2) -> f32 {
     let ab = b - a;
     let ap = point - a;
     let len_sq = ab.length_sq();

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -27,6 +27,15 @@ impl super::View for Footer {
         self.center_widget.update(ui, |ui| {
             ui.centered_and_justified(|ui| {
                 ui.horizontal(|ui| {
+                    // Selection tool button
+                    let selection_btn = Button::new("\u{2b11}")
+                        .fill(Color32::from_gray(8))
+                        .stroke(tool_border(state.active_tool == Tool::Selection))
+                        .min_size(BUTTON_SIZE);
+                    if ui.add(selection_btn).clicked() {
+                        state.active_tool = Tool::Selection;
+                    }
+
                     // Freehand tool button
                     let freehand_btn = Button::new("\u{1f58a}\u{fe0f}")
                         .fill(Color32::from_gray(8))
@@ -49,9 +58,11 @@ impl super::View for Footer {
                                 .min_size(BUTTON_SIZE);
                             if ui.add(btn).clicked() {
                                 state.active_colour = colour;
-                                // Switch back to freehand when picking a colour while erasing
-                                if state.active_tool == Tool::Eraser {
+                                // Switch back to freehand when picking a colour while erasing or selecting
+                                if matches!(state.active_tool, Tool::Eraser | Tool::Selection) {
                                     state.active_tool = Tool::Freehand;
+                                    state.selected_index = None;
+                                    state.drag_offset = None;
                                 }
                             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod eraser;
 mod footer;
 mod header;
 mod palette;
+mod selection;
 mod state;
 
 fn main() -> eframe::Result {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,0 +1,279 @@
+use egui::{emath, Color32, Key, Pos2, Stroke, Vec2};
+
+use crate::eraser;
+use crate::state::{AppState, DrawObject};
+
+/// Selection hit-test tolerance in normalised coordinates.
+const SELECTION_TOLERANCE: f32 = 0.02;
+
+/// Colour of the selection bounding box.
+const SELECTION_COLOUR: Color32 = Color32::from_rgb(100, 160, 255);
+
+/// Padding around the selection bounding box in normalised coordinates.
+const BBOX_PADDING: f32 = 0.005;
+
+/// Returns the index of the topmost object hit at the given normalised position,
+/// iterating in reverse (topmost first).
+pub fn find_object_at(objects: &[DrawObject], pos: Pos2) -> Option<usize> {
+    for (i, obj) in objects.iter().enumerate().rev() {
+        if selection_hit_test(obj, pos) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Hit-test an object for selection purposes (slightly more generous than eraser).
+fn selection_hit_test(object: &DrawObject, pos: Pos2) -> bool {
+    match object {
+        DrawObject::Freehand { points, width, .. } => {
+            let tolerance = SELECTION_TOLERANCE + (*width * 0.002);
+            eraser::distance_to_polyline(pos, points) < tolerance
+        }
+        DrawObject::Rectangle { min, max, .. } => {
+            let rect = egui::Rect::from_min_max(*min, *max);
+            rect.expand(SELECTION_TOLERANCE).contains(pos)
+        }
+        DrawObject::Ellipse {
+            center,
+            radius_x,
+            radius_y,
+            ..
+        } => {
+            let dx = pos.x - center.x;
+            let dy = pos.y - center.y;
+            let r = *radius_x + SELECTION_TOLERANCE;
+            let ry = *radius_y + SELECTION_TOLERANCE;
+            if r <= 0.0 || ry <= 0.0 {
+                return false;
+            }
+            (dx * dx) / (r * r) + (dy * dy) / (ry * ry) <= 1.0
+        }
+        DrawObject::Line { start, end, .. } | DrawObject::Arrow { start, end, .. } => {
+            eraser::distance_to_segment(pos, *start, *end) < SELECTION_TOLERANCE
+        }
+        DrawObject::Text { pos: text_pos, .. } => {
+            let size = 0.05;
+            let rect = egui::Rect::from_min_size(*text_pos, egui::vec2(size, size));
+            rect.expand(SELECTION_TOLERANCE).contains(pos)
+        }
+        DrawObject::Image { pos: img_pos, size } => {
+            let rect = egui::Rect::from_min_size(*img_pos, *size);
+            rect.expand(SELECTION_TOLERANCE).contains(pos)
+        }
+    }
+}
+
+/// Handles selection tool input: click to select, drag to move, Delete to remove.
+pub fn handle_selection_input(
+    response: &egui::Response,
+    state: &mut AppState,
+    from_screen: &emath::RectTransform,
+    ctx: &egui::Context,
+) {
+    // Handle Delete/Backspace to remove selected object
+    if state.selected_index.is_some() {
+        let delete_pressed =
+            ctx.input(|i| i.key_pressed(Key::Delete) || i.key_pressed(Key::Backspace));
+        if delete_pressed {
+            if let Some(idx) = state.selected_index.take() {
+                if idx < state.objects.len() {
+                    state.objects.remove(idx);
+                }
+            }
+            state.drag_offset = None;
+            return;
+        }
+    }
+
+    // Handle pointer interactions
+    if let Some(pointer_pos) = response.interact_pointer_pos() {
+        let canvas_pos = *from_screen * pointer_pos;
+
+        if response.drag_started() {
+            // Starting a new click/drag: try to select an object
+            if let Some(idx) = find_object_at(&state.objects, canvas_pos) {
+                state.selected_index = Some(idx);
+                // Calculate offset from pointer to the object's bounding rect min
+                if let Some(bbox) = state.objects[idx].bounding_rect() {
+                    let offset = Vec2::new(canvas_pos.x - bbox.min.x, canvas_pos.y - bbox.min.y);
+                    state.drag_offset = Some(offset);
+                }
+            } else {
+                // Clicked on empty area: clear selection
+                state.selected_index = None;
+                state.drag_offset = None;
+            }
+        } else if response.dragged() {
+            // Dragging: move the selected object
+            if let (Some(idx), Some(_offset)) = (state.selected_index, state.drag_offset) {
+                if idx < state.objects.len() {
+                    let delta = response.drag_delta();
+                    // Convert screen delta to normalised coordinates
+                    let from_rect = from_screen.to(); // screen rect
+                    let to_rect = from_screen.from(); // normalised rect
+                    let scale_x = to_rect.width() / from_rect.width();
+                    let scale_y = to_rect.height() / from_rect.height();
+                    let normalised_delta = Vec2::new(delta.x * scale_x, delta.y * scale_y);
+                    state.objects[idx].offset_by(normalised_delta);
+                }
+            }
+        }
+    } else {
+        // Pointer released: clear drag offset but keep selection
+        state.drag_offset = None;
+    }
+}
+
+/// Draws a dashed bounding box around the selected object.
+pub fn draw_selection_box(
+    painter: &egui::Painter,
+    state: &AppState,
+    to_screen: &emath::RectTransform,
+) {
+    let idx = match state.selected_index {
+        Some(i) if i < state.objects.len() => i,
+        _ => return,
+    };
+
+    let bbox = match state.objects[idx].bounding_rect() {
+        Some(r) => r,
+        None => return,
+    };
+
+    // Expand bbox slightly and transform to screen space
+    let padded = bbox.expand(BBOX_PADDING);
+    let screen_min = *to_screen * padded.min;
+    let screen_max = *to_screen * padded.max;
+    let screen_rect = egui::Rect::from_min_max(screen_min, screen_max);
+
+    let stroke = Stroke::new(1.5, SELECTION_COLOUR);
+    let dash_length = 5.0;
+    let gap_length = 4.0;
+
+    // Draw dashed rectangle as four dashed sides
+    let corners = [
+        screen_rect.left_top(),
+        screen_rect.right_top(),
+        screen_rect.right_bottom(),
+        screen_rect.left_bottom(),
+    ];
+
+    for i in 0..4 {
+        let a = corners[i];
+        let b = corners[(i + 1) % 4];
+        draw_dashed_line(painter, a, b, stroke, dash_length, gap_length);
+    }
+}
+
+/// Draws a dashed line between two points.
+fn draw_dashed_line(
+    painter: &egui::Painter,
+    a: Pos2,
+    b: Pos2,
+    stroke: Stroke,
+    dash_length: f32,
+    gap_length: f32,
+) {
+    let total_length = a.distance(b);
+    if total_length < 0.1 {
+        painter.line_segment([a, b], stroke);
+        return;
+    }
+
+    let dir = (b - a) / total_length;
+    let mut pos = 0.0;
+    let mut drawing = true;
+
+    while pos < total_length {
+        let segment_len = if drawing { dash_length } else { gap_length };
+        let end = (pos + segment_len).min(total_length);
+
+        if drawing {
+            let start_pt = a + dir * pos;
+            let end_pt = a + dir * end;
+            painter.line_segment([start_pt, end_pt], stroke);
+        }
+
+        pos = end;
+        drawing = !drawing;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui::Color32;
+
+    #[test]
+    fn find_object_at_returns_topmost_hit() {
+        let objects = vec![
+            DrawObject::Freehand {
+                points: vec![Pos2::new(0.5, 0.5), Pos2::new(0.6, 0.5)],
+                colour: Color32::BLACK,
+                width: 2.0,
+            },
+            DrawObject::Rectangle {
+                min: Pos2::new(0.4, 0.4),
+                max: Pos2::new(0.7, 0.7),
+                colour: Color32::RED,
+                width: 2.0,
+            },
+        ];
+
+        // Point inside the rectangle (index 1) which is topmost
+        let result = find_object_at(&objects, Pos2::new(0.55, 0.5));
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn find_object_at_returns_none_for_empty_area() {
+        let objects = vec![DrawObject::Freehand {
+            points: vec![Pos2::new(0.5, 0.5), Pos2::new(0.6, 0.5)],
+            colour: Color32::BLACK,
+            width: 2.0,
+        }];
+
+        let result = find_object_at(&objects, Pos2::new(0.0, 0.0));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_object_at_hits_freehand() {
+        let objects = vec![DrawObject::Freehand {
+            points: vec![Pos2::new(0.5, 0.5), Pos2::new(0.6, 0.5)],
+            colour: Color32::BLACK,
+            width: 2.0,
+        }];
+
+        let result = find_object_at(&objects, Pos2::new(0.55, 0.5));
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn find_object_at_hits_line() {
+        let objects = vec![DrawObject::Line {
+            start: Pos2::new(0.2, 0.2),
+            end: Pos2::new(0.8, 0.8),
+            colour: Color32::BLUE,
+            width: 2.0,
+        }];
+
+        let result = find_object_at(&objects, Pos2::new(0.5, 0.5));
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn find_object_at_hits_ellipse() {
+        let objects = vec![DrawObject::Ellipse {
+            center: Pos2::new(0.5, 0.5),
+            radius_x: 0.1,
+            radius_y: 0.1,
+            colour: Color32::GREEN,
+            width: 2.0,
+        }];
+
+        let result = find_object_at(&objects, Pos2::new(0.5, 0.5));
+        assert_eq!(result, Some(0));
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Pos2};
+use egui::{Color32, Pos2, Rect, Vec2};
 
 /// All available drawing/interaction tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +60,76 @@ pub enum DrawObject {
     },
 }
 
+impl DrawObject {
+    /// Returns the axis-aligned bounding rectangle of this object in normalised coordinates.
+    pub fn bounding_rect(&self) -> Option<Rect> {
+        match self {
+            DrawObject::Freehand { points, .. } => {
+                if points.is_empty() {
+                    return None;
+                }
+                let mut min = points[0];
+                let mut max = points[0];
+                for p in points.iter().skip(1) {
+                    min.x = min.x.min(p.x);
+                    min.y = min.y.min(p.y);
+                    max.x = max.x.max(p.x);
+                    max.y = max.y.max(p.y);
+                }
+                Some(Rect::from_min_max(min, max))
+            }
+            DrawObject::Rectangle { min, max, .. } => Some(Rect::from_min_max(*min, *max)),
+            DrawObject::Ellipse {
+                center,
+                radius_x,
+                radius_y,
+                ..
+            } => Some(Rect::from_center_size(
+                *center,
+                Vec2::new(radius_x * 2.0, radius_y * 2.0),
+            )),
+            DrawObject::Line { start, end, .. } | DrawObject::Arrow { start, end, .. } => {
+                let min = Pos2::new(start.x.min(end.x), start.y.min(end.y));
+                let max = Pos2::new(start.x.max(end.x), start.y.max(end.y));
+                Some(Rect::from_min_max(min, max))
+            }
+            DrawObject::Text { pos, .. } => {
+                let size = 0.05;
+                Some(Rect::from_min_size(*pos, Vec2::new(size, size)))
+            }
+            DrawObject::Image { pos, size } => Some(Rect::from_min_size(*pos, *size)),
+        }
+    }
+
+    /// Moves the object by the given delta in normalised coordinates.
+    pub fn offset_by(&mut self, delta: Vec2) {
+        match self {
+            DrawObject::Freehand { points, .. } => {
+                for p in points.iter_mut() {
+                    *p += delta;
+                }
+            }
+            DrawObject::Rectangle { min, max, .. } => {
+                *min += delta;
+                *max += delta;
+            }
+            DrawObject::Ellipse { center, .. } => {
+                *center += delta;
+            }
+            DrawObject::Line { start, end, .. } | DrawObject::Arrow { start, end, .. } => {
+                *start += delta;
+                *end += delta;
+            }
+            DrawObject::Text { pos, .. } => {
+                *pos += delta;
+            }
+            DrawObject::Image { pos, .. } => {
+                *pos += delta;
+            }
+        }
+    }
+}
+
 /// Shared application state passed to all components each frame.
 pub struct AppState {
     pub active_tool: Tool,
@@ -68,6 +138,10 @@ pub struct AppState {
     pub objects: Vec<DrawObject>,
     /// The freehand stroke currently being drawn (not yet committed to objects).
     pub current_stroke: Option<Vec<Pos2>>,
+    /// Index of the currently selected object (for the Selection tool).
+    pub selected_index: Option<usize>,
+    /// Offset between pointer and object origin when dragging a selected object.
+    pub drag_offset: Option<Vec2>,
 }
 
 impl Default for AppState {
@@ -78,6 +152,8 @@ impl Default for AppState {
             stroke_width: 2.0,
             objects: Vec::new(),
             current_stroke: None,
+            selected_index: None,
+            drag_offset: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Selection tool: click to select objects, drag to move, Delete/Backspace to remove
- Dashed bounding box visual feedback around selected objects
- Selection button added to footer toolbar (cursor icon, placed before freehand)
- Reuses eraser hit-testing logic for consistent object detection
- 5 new tests for selection hit-testing

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (9 tests, 5 new for selection)