### PR TITLE
feat: add screenshot capture with xcap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libgtk-3-dev libpipewire-0.3-dev libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libwayland-dev libegl-dev
+          sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libgtk-3-dev libpipewire-0.3-dev libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libwayland-dev libegl-dev libgbm-dev
 
       - uses: swatinem/rust-cache@v2
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libgtk-3-dev libpipewire-0.3-dev libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libwayland-dev libegl-dev
+          sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libgtk-3-dev libpipewire-0.3-dev libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libwayland-dev libegl-dev libgbm-dev
 
       - uses: swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ libxrandr-dev = "*"
 libdbus-1-dev = "*"
 libwayland-dev = "*"
 libegl-dev = "*"
+libgbm-dev = "*"
 
 # Custom runners for specific targets
 [workspace.metadata.dist.github-custom-runners]

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -182,8 +182,22 @@ impl Canvas {
                     Shape::line_segment([b, tip2], stroke),
                 ]))
             }
-            // Text and Image rendering are placeholder stubs
-            DrawObject::Text { .. } | DrawObject::Image { .. } => None,
+            DrawObject::Image { texture, pos, size } => {
+                let screen_pos = *to_screen * *pos;
+                let screen_size = {
+                    let scale = to_screen.to().size();
+                    let proportions = to_screen.from().size();
+                    Vec2::new(
+                        size.x * scale.x / proportions.x,
+                        size.y * scale.y / proportions.y,
+                    )
+                };
+                let rect = Rect::from_min_size(screen_pos, screen_size);
+                let uv = Rect::from_min_max(Pos2::ZERO, Pos2::new(1.0, 1.0));
+                Some(Shape::image(texture.id(), rect, uv, Color32::WHITE))
+            }
+            // Text rendering is a placeholder stub
+            DrawObject::Text { .. } => None,
         }
     }
 }

--- a/src/eraser.rs
+++ b/src/eraser.rs
@@ -45,7 +45,9 @@ pub fn hit_test(object: &DrawObject, pos: Pos2) -> bool {
             let rect = egui::Rect::from_min_size(*text_pos, egui::vec2(size, size));
             rect.expand(ERASER_TOLERANCE).contains(pos)
         }
-        DrawObject::Image { pos: img_pos, size } => {
+        DrawObject::Image {
+            pos: img_pos, size, ..
+        } => {
             let rect = egui::Rect::from_min_size(*img_pos, *size);
             rect.expand(ERASER_TOLERANCE).contains(pos)
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,6 +1,6 @@
 use egui::Layout;
 
-use crate::state::AppState;
+use crate::state::{AppState, CaptureState};
 
 pub struct Header {
     /// Whether the theme toggle was clicked this frame
@@ -21,10 +21,22 @@ impl Header {
 }
 
 impl super::View for Header {
-    fn render(&mut self, ui: &mut egui::Ui, _state: &mut AppState) {
+    fn render(&mut self, ui: &mut egui::Ui, state: &mut AppState) {
         egui::MenuBar::new().ui(ui, |ui| {
             ui.with_layout(Layout::left_to_right(egui::Align::Center), |ui| {
                 ui.horizontal(|ui| {
+                    let capture_in_progress = state.capture_state != CaptureState::Idle;
+                    let btn = egui::Button::new("Capture");
+                    if ui
+                        .add_enabled(!capture_in_progress, btn)
+                        .on_hover_text("Take a screenshot")
+                        .clicked()
+                    {
+                        state.capture_state = CaptureState::Minimising { frames_waited: 0 };
+                    }
+
+                    ui.separator();
+
                     ui.label("button1");
                     ui.label("button2");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use eframe::{run_native, App, CreationContext, Frame, NativeOptions};
 use egui::{
     CentralPanel, Context, FontData, FontDefinitions, FontFamily, SidePanel, TopBottomPanel,
+    ViewportCommand,
 };
 
 mod canvas;
@@ -11,6 +12,7 @@ mod eraser;
 mod footer;
 mod header;
 mod palette;
+mod screenshot;
 mod state;
 
 fn main() -> eframe::Result {
@@ -110,8 +112,15 @@ impl Snap {
     }
 }
 
+/// Number of frames to wait after minimising before capturing, giving the
+/// window manager time to actually hide the window.
+const MINIMISE_WAIT_FRAMES: u32 = 5;
+
 impl App for Snap {
     fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
+        // Drive the screenshot capture state machine before rendering UI.
+        self.tick_capture(ctx);
+
         TopBottomPanel::top("top_panel")
             .exact_height(64.0)
             .show_separator_line(false)
@@ -141,5 +150,36 @@ impl App for Snap {
             .show(ctx, |ui| ui.label("left"));
 
         CentralPanel::default().show(ctx, |ui| self.canvas.render(ui, &mut self.state));
+    }
+}
+
+impl Snap {
+    /// Advances the screenshot capture state machine by one frame.
+    fn tick_capture(&mut self, ctx: &Context) {
+        match self.state.capture_state {
+            state::CaptureState::Minimising { frames_waited } => {
+                if frames_waited == 0 {
+                    ctx.send_viewport_cmd(ViewportCommand::Minimized(true));
+                }
+
+                if frames_waited >= MINIMISE_WAIT_FRAMES {
+                    // Give the OS a moment to finish the minimise animation.
+                    std::thread::sleep(std::time::Duration::from_millis(300));
+                    screenshot::capture_and_load(ctx, &mut self.state);
+                    ctx.send_viewport_cmd(ViewportCommand::Minimized(false));
+                    self.state.capture_state = state::CaptureState::Restoring;
+                } else {
+                    self.state.capture_state = state::CaptureState::Minimising {
+                        frames_waited: frames_waited + 1,
+                    };
+                    // Request another repaint so we keep ticking.
+                    ctx.request_repaint();
+                }
+            }
+            state::CaptureState::Restoring => {
+                self.state.capture_state = state::CaptureState::Idle;
+            }
+            state::CaptureState::Idle => {}
+        }
     }
 }

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -1,0 +1,49 @@
+use egui::{ColorImage, Context, Pos2, TextureOptions, Vec2};
+use xcap::Monitor;
+
+use crate::state::{AppState, DrawObject};
+
+/// Captures the primary monitor and adds the image to the canvas.
+pub fn capture_and_load(ctx: &Context, state: &mut AppState) {
+    let image = match capture_primary_monitor() {
+        Ok(img) => img,
+        Err(e) => {
+            eprintln!("Screenshot capture failed: {e}");
+            return;
+        }
+    };
+
+    let size = [image.width() as usize, image.height() as usize];
+    let pixels: Vec<egui::Color32> = image
+        .pixels()
+        .map(|p| egui::Color32::from_rgba_premultiplied(p[0], p[1], p[2], p[3]))
+        .collect();
+    let color_image = ColorImage::new(size, pixels);
+
+    let texture = ctx.load_texture("screenshot", color_image, TextureOptions::LINEAR);
+
+    let aspect = size[0] as f32 / size[1] as f32;
+    // Size the image to fill the canvas width in normalised coordinates (0..1).
+    let img_size = Vec2::new(1.0, 1.0 / aspect);
+
+    state.objects.push(DrawObject::Image {
+        texture,
+        pos: Pos2::ZERO,
+        size: img_size,
+    });
+}
+
+/// Captures the primary monitor, falling back to the first available.
+fn capture_primary_monitor() -> Result<image::RgbaImage, String> {
+    let monitors = Monitor::all().map_err(|e| format!("Failed to enumerate monitors: {e}"))?;
+
+    let monitor = monitors
+        .iter()
+        .find(|m| m.is_primary().unwrap_or(false))
+        .or(monitors.first())
+        .ok_or_else(|| "No monitors found".to_string())?;
+
+    monitor
+        .capture_image()
+        .map_err(|e| format!("Failed to capture monitor: {e}"))
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Pos2};
+use egui::{Color32, Pos2, TextureHandle};
 
 /// All available drawing/interaction tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,7 +14,7 @@ pub enum Tool {
 }
 
 /// A single canvas element with its own visual properties.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum DrawObject {
     Freehand {
         /// Points in normalised 0..1 coordinates.
@@ -55,9 +55,105 @@ pub enum DrawObject {
         colour: Color32,
     },
     Image {
+        texture: TextureHandle,
         pos: Pos2,
         size: egui::Vec2,
     },
+}
+
+impl std::fmt::Debug for DrawObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Freehand {
+                points,
+                colour,
+                width,
+            } => f
+                .debug_struct("Freehand")
+                .field("points", points)
+                .field("colour", colour)
+                .field("width", width)
+                .finish(),
+            Self::Rectangle {
+                min,
+                max,
+                colour,
+                width,
+            } => f
+                .debug_struct("Rectangle")
+                .field("min", min)
+                .field("max", max)
+                .field("colour", colour)
+                .field("width", width)
+                .finish(),
+            Self::Ellipse {
+                center,
+                radius_x,
+                radius_y,
+                colour,
+                width,
+            } => f
+                .debug_struct("Ellipse")
+                .field("center", center)
+                .field("radius_x", radius_x)
+                .field("radius_y", radius_y)
+                .field("colour", colour)
+                .field("width", width)
+                .finish(),
+            Self::Line {
+                start,
+                end,
+                colour,
+                width,
+            } => f
+                .debug_struct("Line")
+                .field("start", start)
+                .field("end", end)
+                .field("colour", colour)
+                .field("width", width)
+                .finish(),
+            Self::Arrow {
+                start,
+                end,
+                colour,
+                width,
+            } => f
+                .debug_struct("Arrow")
+                .field("start", start)
+                .field("end", end)
+                .field("colour", colour)
+                .field("width", width)
+                .finish(),
+            Self::Text {
+                pos,
+                content,
+                font_size,
+                colour,
+            } => f
+                .debug_struct("Text")
+                .field("pos", pos)
+                .field("content", content)
+                .field("font_size", font_size)
+                .field("colour", colour)
+                .finish(),
+            Self::Image { pos, size, .. } => f
+                .debug_struct("Image")
+                .field("pos", pos)
+                .field("size", size)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Tracks the screenshot capture state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureState {
+    /// No capture in progress.
+    Idle,
+    /// Window minimise requested; waiting for it to disappear.
+    Minimising { frames_waited: u32 },
+    /// Capture taken; window restore requested.
+    Restoring,
 }
 
 /// Shared application state passed to all components each frame.
@@ -68,6 +164,8 @@ pub struct AppState {
     pub objects: Vec<DrawObject>,
     /// The freehand stroke currently being drawn (not yet committed to objects).
     pub current_stroke: Option<Vec<Pos2>>,
+    /// Screenshot capture state machine.
+    pub capture_state: CaptureState,
 }
 
 impl Default for AppState {
@@ -78,6 +176,7 @@ impl Default for AppState {
             stroke_width: 2.0,
             objects: Vec::new(),
             current_stroke: None,
+            capture_state: CaptureState::Idle,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add "Capture" button to the header toolbar
- Implement minimise-capture-restore flow using a frame-counting state machine
- Capture primary monitor via `xcap::Monitor` and load as egui texture
- Render captured screenshot image on the canvas at origin
- Add `CaptureState` enum to `AppState` for tracking capture lifecycle

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (4 tests)
- [ ] Manual: click Capture button, verify window minimises, screenshot appears on canvas
- [ ] Manual: verify Capture button is disabled during capture